### PR TITLE
initial changes for pg11

### DIFF
--- a/expected/plr.out
+++ b/expected/plr.out
@@ -687,7 +687,7 @@ if (arg2 < 1 || arg3 < 1 || arg4 < 1)
 if (arg2 > dim(arg1)[1] || arg3 > dim(arg1)[2] || arg4 > dim(arg1)[3])
   return(NA)
 return(arg1[arg2,arg3,arg4])
-' language 'plr' WITH (isstrict);
+' language 'plr' STRICT;
 select arr3d('{{{111,112},{121,122},{131,132}},{{211,212},{221,222},{231,232}}}',2,3,1) as "231";
  231 
 -----
@@ -729,7 +729,7 @@ select f1[0][1][1] is null as "NULL" from (select '{{{111,112},{121,122},{131,13
 --
 -- test 3D array return value
 --
-create or replace function arr3d(_int4) returns int4[] as 'return(arg1)' language 'plr' WITH (isstrict);
+create or replace function arr3d(_int4) returns int4[] as 'return(arg1)' language 'plr' STRICT;
 select arr3d('{{{111,112},{121,122},{131,132}},{{211,212},{221,222},{231,232}}}');
                                arr3d                               
 -------------------------------------------------------------------

--- a/pg_conversion.c
+++ b/pg_conversion.c
@@ -476,7 +476,7 @@ pg_tuple_get_r_frame(int ntuples, HeapTuple *tuples, TupleDesc tupdesc)
 	/* Count non-dropped attributes so we can later ignore the dropped ones */
 	for (j = 0; j < nc; j++)
 	{
-		if (!TupleDescAttr(tupdesc,i)->attisdropped)
+		if (!TUPLE_DESC_ATTR(tupdesc,i)->attisdropped)
 			nc_non_dropped++;
 	}
 
@@ -501,7 +501,7 @@ pg_tuple_get_r_frame(int ntuples, HeapTuple *tuples, TupleDesc tupdesc)
 		char		typalign;
 
 		/* ignore dropped attributes */
-		if (TupleDescAttr(tupdesc,j)->attisdropped)
+		if (TUPLE_DESC_ATTR(tupdesc,j)->attisdropped)
 			continue;
 
 		/* set column name */
@@ -800,7 +800,7 @@ get_trigger_tuple(SEXP rval, plr_function *function, FunctionCallInfo fcinfo, bo
 	 */
 	for (j = 0; j < nc; j++)
 	{
-		if (TupleDescAttr(tupdesc,j)->attisdropped)
+		if (TUPLE_DESC_ATTR(tupdesc,j)->attisdropped)
 			nc_dropped++;
 	}
 
@@ -863,7 +863,7 @@ get_trigger_tuple(SEXP rval, plr_function *function, FunctionCallInfo fcinfo, bo
 		for (j = 0; j < nc + nc_dropped; j++)
 		{
 			/* insert NULL for dropped attributes */
-			if (TupleDescAttr(tupdesc,j)->attisdropped)
+			if (TUPLE_DESC_ATTR(tupdesc,j)->attisdropped)
 				values[j] = NULL;
 			else
 			{
@@ -1924,7 +1924,7 @@ get_frame_tuplestore(SEXP rval,
 	{
 		PROTECT(dfcol = VECTOR_ELT(rval, j));
 		if((!isFactor(dfcol)) &&
-		   ((TupleDescAttr(tupdesc,j)->attndims == 0) ||
+		   ((TUPLE_DESC_ATTR(tupdesc,j)->attndims == 0) ||
 			(TYPEOF(dfcol) != VECSXP)))
 		{
 			SEXP	obj;
@@ -1933,7 +1933,7 @@ get_frame_tuplestore(SEXP rval,
 			SET_VECTOR_ELT(result, j, obj);
 			UNPROTECT(1);
 		}
-		else if(TupleDescAttr(tupdesc,j)->attndims != 0)	/* array data type */
+		else if(TUPLE_DESC_ATTR(tupdesc,j)->attndims != 0)	/* array data type */
 		{
 			SEXP	obj;
 
@@ -2009,9 +2009,9 @@ get_frame_tuplestore(SEXP rval,
 			}
 			else
 			{
-				if ((TupleDescAttr(tupdesc,j)->attndims != 0) || (STRING_ELT(dfcol, i) != NA_STRING))
+				if ((TUPLE_DESC_ATTR(tupdesc,j)->attndims != 0) || (STRING_ELT(dfcol, i) != NA_STRING))
 				{
-					if (TupleDescAttr(tupdesc,j)->attndims == 0)
+					if (TUPLE_DESC_ATTR(tupdesc,j)->attndims == 0)
 					{
 						values[j] = pstrdup(CHAR(STRING_ELT(dfcol, i)));
 					}

--- a/pg_conversion.c
+++ b/pg_conversion.c
@@ -1878,7 +1878,6 @@ get_frame_tuplestore(SEXP rval,
 	HeapTuple			tuple;
 	TupleDesc			tupdesc = attinmeta->tupdesc;
 	int					tupdesc_nc = tupdesc->natts;
-	Form_pg_attribute  attrs = tupdesc->attrs;
 	MemoryContext		oldcontext;
 	int					i, j;
 	int					nr = 0;
@@ -1925,7 +1924,7 @@ get_frame_tuplestore(SEXP rval,
 	{
 		PROTECT(dfcol = VECTOR_ELT(rval, j));
 		if((!isFactor(dfcol)) &&
-		   ((attrs[j].attndims == 0) ||
+		   ((TupleDescAttr(tupdesc,j)->attndims == 0) ||
 			(TYPEOF(dfcol) != VECSXP)))
 		{
 			SEXP	obj;
@@ -1934,7 +1933,7 @@ get_frame_tuplestore(SEXP rval,
 			SET_VECTOR_ELT(result, j, obj);
 			UNPROTECT(1);
 		}
-		else if(attrs[j].attndims != 0)	/* array data type */
+		else if(TupleDescAttr(tupdesc,j)->attndims != 0)	/* array data type */
 		{
 			SEXP	obj;
 
@@ -2010,9 +2009,9 @@ get_frame_tuplestore(SEXP rval,
 			}
 			else
 			{
-				if ((attrs[j].attndims != 0) || (STRING_ELT(dfcol, i) != NA_STRING))
+				if ((TupleDescAttr(tupdesc,j)->attndims != 0) || (STRING_ELT(dfcol, i) != NA_STRING))
 				{
-					if (attrs[j].attndims == 0)
+					if (TupleDescAttr(tupdesc,j)->attndims == 0)
 					{
 						values[j] = pstrdup(CHAR(STRING_ELT(dfcol, i)));
 					}

--- a/pg_conversion.c
+++ b/pg_conversion.c
@@ -476,7 +476,7 @@ pg_tuple_get_r_frame(int ntuples, HeapTuple *tuples, TupleDesc tupdesc)
 	/* Count non-dropped attributes so we can later ignore the dropped ones */
 	for (j = 0; j < nc; j++)
 	{
-		if (!tupdesc->attrs[j]->attisdropped)
+		if (!tupdesc->attrs[j].attisdropped)
 			nc_non_dropped++;
 	}
 
@@ -501,7 +501,7 @@ pg_tuple_get_r_frame(int ntuples, HeapTuple *tuples, TupleDesc tupdesc)
 		char		typalign;
 
 		/* ignore dropped attributes */
-		if (tupdesc->attrs[j]->attisdropped)
+		if (tupdesc->attrs[j].attisdropped)
 			continue;
 
 		/* set column name */
@@ -800,7 +800,7 @@ get_trigger_tuple(SEXP rval, plr_function *function, FunctionCallInfo fcinfo, bo
 	 */
 	for (j = 0; j < nc; j++)
 	{
-		if (tupdesc->attrs[j]->attisdropped)
+		if (tupdesc->attrs[j].attisdropped)
 			nc_dropped++;
 	}
 
@@ -863,7 +863,7 @@ get_trigger_tuple(SEXP rval, plr_function *function, FunctionCallInfo fcinfo, bo
 		for (j = 0; j < nc + nc_dropped; j++)
 		{
 			/* insert NULL for dropped attributes */
-			if (tupdesc->attrs[j]->attisdropped)
+			if (tupdesc->attrs[j].attisdropped)
 				values[j] = NULL;
 			else
 			{
@@ -1878,7 +1878,7 @@ get_frame_tuplestore(SEXP rval,
 	HeapTuple			tuple;
 	TupleDesc			tupdesc = attinmeta->tupdesc;
 	int					tupdesc_nc = tupdesc->natts;
-	Form_pg_attribute  *attrs = tupdesc->attrs;
+	Form_pg_attribute  attrs = tupdesc->attrs;
 	MemoryContext		oldcontext;
 	int					i, j;
 	int					nr = 0;
@@ -1925,7 +1925,7 @@ get_frame_tuplestore(SEXP rval,
 	{
 		PROTECT(dfcol = VECTOR_ELT(rval, j));
 		if((!isFactor(dfcol)) &&
-		   ((attrs[j]->attndims == 0) ||
+		   ((attrs[j].attndims == 0) ||
 			(TYPEOF(dfcol) != VECSXP)))
 		{
 			SEXP	obj;
@@ -1934,7 +1934,7 @@ get_frame_tuplestore(SEXP rval,
 			SET_VECTOR_ELT(result, j, obj);
 			UNPROTECT(1);
 		}
-		else if(attrs[j]->attndims != 0)	/* array data type */
+		else if(attrs[j].attndims != 0)	/* array data type */
 		{
 			SEXP	obj;
 
@@ -2010,9 +2010,9 @@ get_frame_tuplestore(SEXP rval,
 			}
 			else
 			{
-				if ((attrs[j]->attndims != 0) || (STRING_ELT(dfcol, i) != NA_STRING))
+				if ((attrs[j].attndims != 0) || (STRING_ELT(dfcol, i) != NA_STRING))
 				{
-					if (attrs[j]->attndims == 0)
+					if (attrs[j].attndims == 0)
 					{
 						values[j] = pstrdup(CHAR(STRING_ELT(dfcol, i)));
 					}

--- a/pg_conversion.c
+++ b/pg_conversion.c
@@ -476,7 +476,7 @@ pg_tuple_get_r_frame(int ntuples, HeapTuple *tuples, TupleDesc tupdesc)
 	/* Count non-dropped attributes so we can later ignore the dropped ones */
 	for (j = 0; j < nc; j++)
 	{
-		if (!tupdesc->attrs[j].attisdropped)
+		if (!TupleDescAttr(tupdesc,i)->attisdropped)
 			nc_non_dropped++;
 	}
 
@@ -501,7 +501,7 @@ pg_tuple_get_r_frame(int ntuples, HeapTuple *tuples, TupleDesc tupdesc)
 		char		typalign;
 
 		/* ignore dropped attributes */
-		if (tupdesc->attrs[j].attisdropped)
+		if (TupleDescAttr(tupdesc,j)->attisdropped)
 			continue;
 
 		/* set column name */
@@ -800,7 +800,7 @@ get_trigger_tuple(SEXP rval, plr_function *function, FunctionCallInfo fcinfo, bo
 	 */
 	for (j = 0; j < nc; j++)
 	{
-		if (tupdesc->attrs[j].attisdropped)
+		if (TupleDescAttr(tupdesc,j)->attisdropped)
 			nc_dropped++;
 	}
 
@@ -863,7 +863,7 @@ get_trigger_tuple(SEXP rval, plr_function *function, FunctionCallInfo fcinfo, bo
 		for (j = 0; j < nc + nc_dropped; j++)
 		{
 			/* insert NULL for dropped attributes */
-			if (tupdesc->attrs[j].attisdropped)
+			if (TupleDescAttr(tupdesc,j)->attisdropped)
 				values[j] = NULL;
 			else
 			{

--- a/pg_userfuncs.c
+++ b/pg_userfuncs.c
@@ -322,8 +322,8 @@ plr_environ(PG_FUNCTION_ARGS)
 	 * Check to make sure we have a reasonable tuple descriptor
 	 */
 	if (tupdesc->natts != 2 ||
-		tupdesc->attrs[0].atttypid != TEXTOID ||
-		tupdesc->attrs[1].atttypid != TEXTOID)
+		TUPLE_DESC_ATTR(tupdesc,0)->atttypid != TEXTOID ||
+		TUPLE_DESC_ATTR(tupdesc,0)->atttypid != TEXTOID)
 		ereport(ERROR,
 				(errcode(ERRCODE_SYNTAX_ERROR),
 				 errmsg("query-specified return tuple and "

--- a/pg_userfuncs.c
+++ b/pg_userfuncs.c
@@ -322,8 +322,8 @@ plr_environ(PG_FUNCTION_ARGS)
 	 * Check to make sure we have a reasonable tuple descriptor
 	 */
 	if (tupdesc->natts != 2 ||
-		tupdesc->attrs[0]->atttypid != TEXTOID ||
-		tupdesc->attrs[1]->atttypid != TEXTOID)
+		tupdesc->attrs[0].atttypid != TEXTOID ||
+		tupdesc->attrs[1].atttypid != TEXTOID)
 		ereport(ERROR,
 				(errcode(ERRCODE_SYNTAX_ERROR),
 				 errmsg("query-specified return tuple and "

--- a/plr.c
+++ b/plr.c
@@ -1576,12 +1576,12 @@ plr_convertargs(plr_function *function, Datum *arg, bool *argnull, FunctionCallI
 		else
 		{
 			Datum			dvalue;
-			bool			isnull;
+			bool			isnull,isout;
 			WindowObject	winobj = PG_WINDOW_OBJECT();
 
 			/* get datum for the current row of the window frame */
-			dvalue = WinGetFuncArgInFrame(winobj, i, 0, WINDOW_SEEK_CURRENT, false, &isnull, NULL);
-
+			dvalue = WinGetFuncArgInPartition(winobj, i, 0, WINDOW_SEEK_CURRENT, false, &isnull, &isout);
+			/* I think we can ignore isout as isnull should be set and null will be returned */ 
 			if (isnull)
 			{
 				/* fast track for null arguments */

--- a/plr.c
+++ b/plr.c
@@ -955,8 +955,11 @@ do_compile(FunctionCallInfo fcinfo,
 	function->fn_tid = procTup->t_self;
 
 #ifdef HAVE_WINDOW_FUNCTIONS
-	/* Flag for window functions */
+#if PG_VERSION_NUM >= 110000
+	function->iswindow = (procStruct->prokind == PROKIND_WINDOW);
+#else
 	function->iswindow = procStruct->proiswindow;
+#endif
 #endif
 
 	/* Lookup the pg_language tuple by Oid*/
@@ -1074,7 +1077,7 @@ do_compile(FunctionCallInfo fcinfo,
 	
 			for (i = 0; i < function->result_natts; i++)
 			{
-				function->result_fld_elem_typid[i] = get_element_type(tupdesc->attrs[i]->atttypid);
+				function->result_fld_elem_typid[i] = get_element_type(tupdesc->attrs[i].atttypid);
 				if (OidIsValid(function->result_fld_elem_typid[i]))
 				{
 					get_type_io_data(function->result_fld_elem_typid[i], IOFunc_input,

--- a/plr.c
+++ b/plr.c
@@ -1077,7 +1077,7 @@ do_compile(FunctionCallInfo fcinfo,
 	
 			for (i = 0; i < function->result_natts; i++)
 			{
-				function->result_fld_elem_typid[i] = get_element_type(TupleDescAttr(tupdesc,i)->atttypid);
+				function->result_fld_elem_typid[i] = get_element_type(TUPLE_DESC_ATTR(tupdesc,i)->atttypid);
 				if (OidIsValid(function->result_fld_elem_typid[i]))
 				{
 					get_type_io_data(function->result_fld_elem_typid[i], IOFunc_input,

--- a/plr.c
+++ b/plr.c
@@ -1077,7 +1077,7 @@ do_compile(FunctionCallInfo fcinfo,
 	
 			for (i = 0; i < function->result_natts; i++)
 			{
-				function->result_fld_elem_typid[i] = get_element_type(tupdesc->attrs[i].atttypid);
+				function->result_fld_elem_typid[i] = get_element_type(TupleDescAttr(tupdesc,i)->atttypid);
 				if (OidIsValid(function->result_fld_elem_typid[i]))
 				{
 					get_type_io_data(function->result_fld_elem_typid[i], IOFunc_input,

--- a/plr.h
+++ b/plr.h
@@ -157,6 +157,12 @@ extern int R_SignalHandlers;
 #define HAVE_WINDOW_FUNCTIONS
 #endif
 
+#if PG_VERSION_NUM >= 110000 
+#define TUPLE_DESC_ATTR(tupdesc,i) TupleDescAttr(tupdesc,i)
+#else 
+#define TUPLE_DESC_ATTR(tupdesc,i) tupdesc->attrs[i] 
+#endif
+		
 #ifdef DEBUGPROTECT
 #undef PROTECT
 extern SEXP pg_protect(SEXP s, char *fn, int ln);

--- a/sql/plr.sql
+++ b/sql/plr.sql
@@ -297,7 +297,7 @@ if (arg2 < 1 || arg3 < 1 || arg4 < 1)
 if (arg2 > dim(arg1)[1] || arg3 > dim(arg1)[2] || arg4 > dim(arg1)[3])
   return(NA)
 return(arg1[arg2,arg3,arg4])
-' language 'plr' STRICT; 
+' language 'plr' STRICT;
 
 select arr3d('{{{111,112},{121,122},{131,132}},{{211,212},{221,222},{231,232}}}',2,3,1) as "231";
 -- for sake of comparison, see what normal pgsql array operations produces
@@ -312,7 +312,7 @@ select f1[0][1][1] is null as "NULL" from (select '{{{111,112},{121,122},{131,13
 --
 -- test 3D array return value
 --
-create or replace function arr3d(_int4) returns int4[] as 'return(arg1)' language 'plr' STRICT;  
+create or replace function arr3d(_int4) returns int4[] as 'return(arg1)' language 'plr' STRICT;
 select arr3d('{{{111,112},{121,122},{131,132}},{{211,212},{221,222},{231,232}}}');
 
 --

--- a/sql/plr.sql
+++ b/sql/plr.sql
@@ -297,7 +297,7 @@ if (arg2 < 1 || arg3 < 1 || arg4 < 1)
 if (arg2 > dim(arg1)[1] || arg3 > dim(arg1)[2] || arg4 > dim(arg1)[3])
   return(NA)
 return(arg1[arg2,arg3,arg4])
-' language 'plr' WITH (isstrict);
+' language 'plr' STRICT; 
 
 select arr3d('{{{111,112},{121,122},{131,132}},{{211,212},{221,222},{231,232}}}',2,3,1) as "231";
 -- for sake of comparison, see what normal pgsql array operations produces
@@ -312,7 +312,7 @@ select f1[0][1][1] is null as "NULL" from (select '{{{111,112},{121,122},{131,13
 --
 -- test 3D array return value
 --
-create or replace function arr3d(_int4) returns int4[] as 'return(arg1)' language 'plr' WITH (isstrict);
+create or replace function arr3d(_int4) returns int4[] as 'return(arg1)' language 'plr' STRICT;  
 select arr3d('{{{111,112},{121,122},{131,132}},{{211,212},{221,222},{231,232}}}');
 
 --


### PR DESCRIPTION
specifically using prokind instead of iswindow

There are a number of regressions that I can't figure out:

specifically the server

```
create or replace function arr3d(_int4,int4,int4,int4) returns int4 as '
if (arg2 < 1 || arg3 < 1 || arg4 < 1)
  return(NA)
if (arg2 > dim(arg1)[1] || arg3 > dim(arg1)[2] || arg4 > dim(arg1)[3])
  return(NA)
return(arg1[arg2,arg3,arg4])
' language 'plr' STRICT;
```
insists on putting a space at the end of STRICT;
and this one 

! ERROR:  WINDOW_SEEK_CURRENT is not supported for WinGetFuncArgInFrame
! CONTEXT:  In PL/R function r_regr_slope

which I presume is an R difference @jconway ?