### PR TITLE
MS Visual Studio project file and multi-PG Appveyor builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,24 +3,32 @@ os:
 
 language: c
 sudo : required 
+env:
+  - PG=11
+  - PG=10
+  - PG=9.6
+  - PG=9.5
+  - PG=9.4
+  - PG=9.3
 
 before_script:
-  - sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt/ trusty-pgdg main" >> /etc/apt/sources.list.d/postgresql.list'
+  - sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
   - wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
   - sudo apt-get update -qq
   - sudo apt-get install -qq r-base
   - sudo apt-get install -qq r-base-dev
   - sudo /etc/init.d/postgresql stop
   - sudo apt-get remove --purge postgresql\*
-  - sudo apt-get install postgresql-10
-  - sudo apt-get install postgresql-server-dev-10
-  - echo 'local   all             postgres                                trust' | sudo tee /etc/postgresql/10/main/pg_hba.conf > /dev/null
-  - sudo pg_ctlcluster 10 main reload
+  - sudo rm -rf /etc/postgresql /var/lib/postgresql
+  - sudo apt-get install postgresql-$PG
+  - sudo apt-get install postgresql-server-dev-$PG
+  - echo 'local   all             postgres                                trust' | sudo tee /etc/postgresql/$PG/main/pg_hba.conf > /dev/null
+  - sudo pg_ctlcluster $PG main reload
 script:
   - sudo pg_lsclusters
   - export USE_PGXS=1
   - make 
   - sudo  make install
-  - /usr/lib/postgresql/10/bin/pg_config
+  - /usr/lib/postgresql/$PG/bin/pg_config
   - psql --version 
-  - /usr/lib/postgresql/10/lib/pgxs/src/makefiles/../../src/test/regress/pg_regress --user=postgres --inputdir=./ --bindir='/usr/lib/postgresql/10/bin/' --dbname=contrib_regression plr
+  - make installcheck PGUSER=postgres || (cat regression.diffs && false)

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,20 +15,24 @@ before_script:
   - sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
   - wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
   - sudo apt-get update -qq
-  - sudo apt-get install -qq r-base
-  - sudo apt-get install -qq r-base-dev
+  - sudo apt-get install -qq r-base-dev acl
   - sudo /etc/init.d/postgresql stop
   - sudo apt-get remove --purge postgresql\*
   - sudo rm -rf /etc/postgresql /var/lib/postgresql
   - sudo apt-get install postgresql-$PG
   - sudo apt-get install postgresql-server-dev-$PG
   - echo 'local   all             postgres                                trust' | sudo tee /etc/postgresql/$PG/main/pg_hba.conf > /dev/null
+  - setfacl -Rm u:postgres:rwx,d:u:travis:rwx $HOME
   - sudo pg_ctlcluster $PG main reload
+
 script:
   - sudo pg_lsclusters
   - export USE_PGXS=1
-  - make 
+  - SHLIB_LINK=-lgcov PG_CPPFLAGS="-fprofile-arcs -ftest-coverage -O0" make
   - sudo  make install
   - /usr/lib/postgresql/$PG/bin/pg_config
   - psql --version 
   - make installcheck PGUSER=postgres || (cat regression.diffs && false)
+
+after_success:
+  - bash <(curl -s https://codecov.io/bash)

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ OBJS		:= $(SRCS:.c=.o)
 SHLIB_LINK	+= -L$(r_libdir1x) -L$(r_libdir2x) -lR
 DATA_built	= plr.sql
 DATA		= plr--8.3.0.18.sql plr--unpackaged--8.3.0.18.sql
-REGRESS		= plr
+REGRESS		= plr bad_fun
 
 ifdef USE_PGXS
 ifndef PG_CONFIG

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ SRCS		+= plr.c pg_conversion.c pg_backend_support.c pg_userfuncs.c pg_rsupport.c
 OBJS		:= $(SRCS:.c=.o)
 SHLIB_LINK	+= -L$(r_libdir1x) -L$(r_libdir2x) -lR
 DATA_built	= plr.sql
-DATA		= plr--8.3.0.18.sql plr--unpackaged--8.3.0.18.sql
+DATA		= plr--8.4.sql plr--8.3.0.18--8.4.sql plr--unpackaged--8.4.sql
 REGRESS		= plr bad_fun
 
 ifdef USE_PGXS

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-
 ### PL/R - PostgreSQL support for R as a procedural language (PL)
+[![AppVeyor build status](https://ci.appveyor.com/api/projects/status/github/postgres-plr/plr)](https://ci.appveyor.com/project/davecramer/plr-daun5) [![Travis build Status](https://travis-ci.org/postgres-plr/plr.png)](https://travis-ci.org/postgres-plr/plr) [![Code coverage](https://img.shields.io/codecov/c/github/postgres-plr/plr.svg?maxAge=2592000)](https://codecov.io/github/postgres-plr/plr)
 
  Copyright (c) 2003-2018 by Joseph E. Conway ALL RIGHTS RESERVED
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -132,7 +132,7 @@ test_script:
     }
     $env:Outcome="Passed"
     $elapsed=(Measure-Command {
-      pg_regress "$env:psqlopt=$env:pgroot\bin" --dbname=pl_regression plr 2>&1 |
+      pg_regress "$env:psqlopt=$env:pgroot\bin" --dbname=pl_regression plr bad_fun 2>&1 |
         %{ if ($_ -is [System.Management.Automation.ErrorRecord]) { $_.Exception.Message } else { $_ } } |
           Out-Default
       if ($LASTEXITCODE -ne 0) {

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,69 +1,158 @@
-#  appveyor.yml
+image: Visual Studio 2015
+configuration: Release
+platform:
+  - x86
+  - x64
+clone_depth: 1
+environment:
+  PGUSER: postgres
+  PGPASSWORD: Password12!
+  rversion: 3.5.1
+  matrix:
+  - pg: master
+    PlatformToolset: v141
+    configuration: Debug
+    APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+  - pg: 9.3.24-1
+    PlatformToolset: Windows7.1SDK
+  - pg: 9.4.19-1
+    PlatformToolset: v120
+  - pg: 9.5.15-1
+    PlatformToolset: v120
+  - pg: 9.6.11-1
+    PlatformToolset: v120
+  - pg: 10.6-1
+    PlatformToolset: v120
+  - pg: 11.1-1
+    PlatformToolset: v140
+matrix:
+  allow_failures:
+    - pg: master
+  exclude:
+    - platform: x86
+      pg: 11.1-1
+      PlatformToolset: v140
+    - platform: x86
+      pg: master
 
+init: # Make %x64% available for caching
+- if %PLATFORM%==x64 ( set pf=%ProgramFiles%&& set x64=-x64) else set pf=%ProgramFiles(x86)%
+- set exe=postgresql-%pg%-windows%x64%.exe
+- setx /m exe %exe%
 
-init:
-  - ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
-  
 install:
-  - appveyor downloadfile https://cran.rstudio.com/bin/windows/base/R-3.5.1-win.exe 
-  - R-3.5.1-win.exe /VERYSILENT /dir=C:\R-3.5.1
-  - git clone https://git.postgresql.org/git/postgresql.git c:\projects\postgresql
-  - cd c:\projects\postgresql
-  - git checkout REL_11_STABLE
-  - cd c:\projects
-  - ren %APPVEYOR_PROJECT_SLUG% plr
-  - mv plr postgresql\contrib\
-  - cd c:\projects\postgresql
-  - cinst winflexbison
-  - SET R_HOME=C:\R-3.5.1
-  - '"C:\Program Files\Microsoft SDKs\Windows\v7.1\Bin\SetEnv.cmd" /x64'
-  
-before_build:
-  - net user testuser Blurfl9426! /add
-  - rename c:\ProgramData\chocolatey\bin\win_flex.exe flex.exe
-  - rename c:\ProgramData\chocolatey\bin\win_bison.exe bison.exe
-  - cd c:\projects\postgresql
-  - perl c:\projects\postgresql\contrib\plr\buildsetup.pl
-  - dumpbin /EXPORTS C:\R-3.5.1\bin\x64\R.dll > c:\projects\postgresql\contrib\plr\R.symbols
-  - tail -n +19 c:\projects\postgresql\contrib\plr\R.symbols  | tr -s ' ' |cut -d ' ' -f 5 > c:\projects\postgresql\contrib\plr\R.stripped
-  - cat c:\projects\postgresql\contrib\plr\header.def c:\projects\postgresql\contrib\plr\R.stripped > c:\projects\postgresql\contrib\plr\R.def
-  - lib /def:c:\projects\postgresql\contrib\plr\R.def /out:C:\R-3.5.1\bin\x64\R.lib
-  - SET PATH=%PATH%;C:\R-3.5.1\bin\x64\
-  - patch -p1 < contrib\plr\msvc.diff
+- if not exist R-%rversion%-win.exe appveyor downloadfile https://cran.rstudio.com/bin/windows/base/R-%rversion%-win.exe
+- R-%rversion%-win.exe /VERYSILENT
+# We could have used RTools many R users have, but let's use msys64 existing on Appveyor intead
+#- if not exist Rtools35.exe appveyor downloadfile https://cran.r-project.org/bin/windows/Rtools/Rtools35.exe
+#- Rtools35.exe /VERYSILENT
+- Set mingw=C:\msys64\mingw
+# http://www.databasesoup.com/2016/05/changing-postgresql-version-numbering.html
+- for /f "tokens=1 delims=-" %%A in ("%pg%") do set pgversion=%%~nA
+- echo pgversion=%pgversion%
+- set pgroot=%pf%\PostgreSQL\%pgversion%
+- echo %pgroot%
+- SET R_HOME=%ProgramFiles%\R\R-%rversion%
+- set RBIN=%PLATFORM:x86=i386%
+- SET sed=C:\msys64\usr\bin\sed
+- ps: |
+    if ("$env:pg" -eq "master") {
+      $env:Path += ";C:\msys64\usr\bin;C:\msys64\mingw64\bin;C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\bin\amd64"
+      git clone -q --depth 1 https://git.postgresql.org/git/postgresql.git c:\projects\postgresql
+      gendef - "$env:R_HOME\bin\$env:rbin\R.dll" > "R$env:PLATFORM.def" 2> $null
+      lib "/def:R$env:PLATFORM.def" "/out:R$env:PLATFORM.lib" "/MACHINE:$env:PLATFORM"
+      pushd c:\projects\postgresql
+      cmd /c mklink /J contrib\plr $env:APPVEYOR_BUILD_FOLDER
+      patch -p1 -i "$env:APPVEYOR_BUILD_FOLDER\msvc.diff"
+      perl contrib\plr\buildsetup.pl
+      popd
+      $env:PROJ="C:\projects\postgresql\pgsql.sln"
+      $env:dll="c:\projects\postgresql\$env:CONFIGURATION\plr\plr.dll"
+    } else {
+      $env:PROJ="plr.vcxproj"
+      $env:dll="$($env:PLATFORM.replace('x86', '.'))\$env:CONFIGURATION\plr.dll"
+      if (-not (Test-Path "$env:pgroot\bin")) {
+        if (-not (Test-Path "$env:exe")) {
+          Start-FileDownload "http://get.enterprisedb.com/postgresql/$env:exe"
+        }
+        & ".\$env:exe" --unattendedmodeui none --mode unattended --superpassword "$env:PGPASSWORD" --servicepassword "$env:PGPASSWORD" | Out-Null
+        Stop-Service "postgresql$env:x64-$env:pgversion"
+      }
+    }
+
+cache:
+- '%exe%'
+- R-%rversion%-win.exe
 
 build_script:
-  - cd c:\projects\postgresql\src\tools\msvc
-  - build.bat
-  
-configuration:
-  - Release
-  
+- msbuild /p:PlatformToolset=%PlatformToolset% /p:configuration=%CONFIGURATION% /p:platform=%PLATFORM%
+          %PROJ%
+          /verbosity:minimal /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
+
+after_build:
+- appveyor AddMessage Packing -Category Information
+- md tmp\share\extension
+- copy *.sql tmp\share\extension\
+- copy *.control tmp\share\extension\
+- copy LICENSE tmp\PLR_LICENSE
+- md tmp\lib
+- md tmp\symbols
+- copy %dll% tmp\lib
+- copy %dll:.dll=.pdb% tmp\symbols
+- set zip=plr-%APPVEYOR_REPO_COMMIT:~0,8%-pg%pgversion%-R%rversion%-%PLATFORM%-%CONFIGURATION%.zip
+- 7z a -r %zip% .\tmp\* > nul
+- ps: |
+    if ("$env:pg" -eq "master") {
+      pushd c:\projects\postgresql\src\tools\msvc
+      perl install.pl "$env:pgroot"
+      popd
+    }
+
 test_script:
-  - SET R_HOME=C:\R-3.5.1
-  - SET PATH=%PATH%;C:\R-3.5.1\bin\x64
-  - cd c:\projects\postgresql\src\tools\msvc
-  - perl install.pl c:\pgsql
-  - cd c:\pgsql
-  - bin\initdb -D data
-  - ps: Start-Process -FilePath .\bin\pg_ctl -ArgumentList "-D data -l logfile start"
-  - cd c:\projects\postgresql\contrib\plr
-  - cp plr.control c:\pgsql\share\extension
-  - cp plr--8.3.0.18.sql c:\pgsql\share\extension
-  - mkdir c:\projects\%APPVEYOR_PROJECT_SLUG%
-  - cp c:\projects\postgresql\Release\plr\plr.dll c:\projects\%APPVEYOR_PROJECT_SLUG%\
-  - ps: Start-Process -FilePath ..\..\Release\pg_regress\pg_regress -ArgumentList "--bindir=c:\pgsql\bin --dbname=pl_regression plr"
-        
+- path %pgroot%\bin;%PATH%
+- ps: |
+    if ("$env:pg" -eq "master") {
+      Set-Content -path pg.pass -value "$env:pgpassword" -encoding ascii
+      initdb -A md5 -U "$env:PGUSER" --pwfile=pg.pass C:\pgdata
+      pg_ctl register -S demand -N "postgresql$env:x64-$env:pgversion" -D c:\pgdata
+    } else {
+      Add-AppveyorMessage "Copying the extension files to the PostgreSQL directories." -Category Information
+      7z x "$env:zip" "-o$env:pgroot"
+    }
+- appveyor AddMessage "Starting the database server." -Category Information
+- setx /M PATH "%R_HOME%\bin\%RBIN%;%PATH%"
+- net start postgresql%x64%-%pgversion%
+
+- ps: |
+    Add-AppveyorTest Regression -Framework pg_regress -FileName sql\ -Outcome Running
+    if (("9.3", "9.4").Contains("$env:pgversion")) {
+      $env:psqlopt="--psqldir"
+    } else {
+      $env:psqlopt="--bindir"
+    }
+    $env:Outcome="Passed"
+    $elapsed=(Measure-Command {
+      pg_regress "$env:psqlopt=$env:pgroot\bin" --dbname=pl_regression plr 2>&1 |
+        %{ if ($_ -is [System.Management.Automation.ErrorRecord]) { $_.Exception.Message } else { $_ } } |
+          Out-Default
+      if ($LASTEXITCODE -ne 0) {
+        $env:Outcome="Failed"
+      }
+    }).TotalMilliseconds
+    Update-AppVeyorTest Regression -Framework pg_regress -FileName sql\ -Outcome "$env:Outcome" -Duration $elapsed
+    if ("$env:Outcome" -ne "Passed") {
+      type regression.diffs
+    }
+
+artifacts:
+- path: '*.zip'
+
 deploy:
    provider: GitHub
    release: $(appveyor_repo_tag_name)
-   artifact: plr.dll
    draft: false
    prerelease: false
    auth_token:
       secure: v+5LgZlgiwCjr45eTclZ2s7YJIvRi+DeRPQO0HWbkCKj8iIjlXEDw27P3jkMrqiD
    on:
       appveyor_repo_tag: true
-         
-artifacts:
-  - path: '.\plr.dll'
-    name: plr.dll

--- a/expected/bad_fun.out
+++ b/expected/bad_fun.out
@@ -1,0 +1,13 @@
+-- should error out but should not crash PG
+CREATE OR REPLACE
+FUNCTION r_bad_fun()
+RETURNS int4 AS
+$BODY$
+  deadbeef <- function(,bad) {}
+  42
+$BODY$
+LANGUAGE plr;
+SELECT r_bad_fun();
+ERROR:  R interpreter parse error
+DETAIL:  Error: bad value
+CONTEXT:  In PL/R function r_bad_fun

--- a/expected/plr.out
+++ b/expected/plr.out
@@ -9,7 +9,7 @@ set client_min_messages to notice;
 SELECT plr_version();
  plr_version 
 -------------
- 08.03.00.18
+ 08.04
 (1 row)
 
 -- make typenames available in the global namespace

--- a/msvc.diff
+++ b/msvc.diff
@@ -20,8 +20,8 @@ index a083ac7..fcf44b7 100644
 +		'contrib\plr','plr.c','pg_conversion.c','pg_backend_support.c','pg_userfuncs.c','pg_rsupport.c'
 +	);
 +	$plr->AddReference($postgres);
-+	$plr->AddLibrary('C:\R-3.5.1\bin\x64\R.lib');
-+	$plr->AddIncludeDir('C:\R-3.5.1\include');
++	$plr->AddLibrary('contrib/plr/R$(PlatformTarget).lib');
++	$plr->AddIncludeDir('$(R_HOME)\include');
 +	my $mfplr = Project::read_file('contrib/plr/Makefile');
 +	GenerateContribSqlFiles('plr', $mfplr);
 +

--- a/pg_backend_support.c
+++ b/pg_backend_support.c
@@ -316,6 +316,7 @@ expand_dynamic_library_name(const char *name)
 
 	have_slash = (strchr(name, '/') != NULL);
 
+#ifndef WIN32
 	if (!have_slash)
 	{
 		full = find_in_dynamic_libpath(name);
@@ -329,6 +330,7 @@ expand_dynamic_library_name(const char *name)
 			return full;
 		pfree(full);
 	}
+#endif
 
 	new = palloc(strlen(name) + strlen(DLSUFFIX) + 1);
 	strcpy(new, name);

--- a/pg_rsupport.c
+++ b/pg_rsupport.c
@@ -597,6 +597,7 @@ plr_SPI_execp(SEXP rsaved_plan, SEXP rargvalues)
 	return result;
 }
 
+#if CATALOG_VERSION_NO < 201811201
 /*
  * plr_SPI_lastoid - return the last oid. To be used after insert queries.
  */
@@ -611,6 +612,7 @@ plr_SPI_lastoid(void)
 
 	return result;
 }
+#endif
 
 /*
  * Takes the prepared plan rsaved_plan and creates a cursor 

--- a/plr--8.3.0.18--8.4.sql
+++ b/plr--8.3.0.18--8.4.sql
@@ -1,0 +1,10 @@
+CREATE OR REPLACE FUNCTION r_typenames()
+RETURNS SETOF r_typename AS '
+  within(data.frame(
+    typename = ls(name = .GlobalEnv, pat = "OID"),
+    stringsAsFactors = FALSE
+  ),
+  {
+    typeoid <- sapply(typename, get)
+  })
+' language 'plr';

--- a/plr--8.4.sql
+++ b/plr--8.4.sql
@@ -48,10 +48,13 @@ REVOKE EXECUTE ON FUNCTION plr_environ() FROM PUBLIC;
 CREATE TYPE r_typename AS (typename text, typeoid oid);
 CREATE OR REPLACE FUNCTION r_typenames()
 RETURNS SETOF r_typename AS '
-  x <- ls(name = .GlobalEnv, pat = "OID")
-  y <- vector()
-  for (i in 1:length(x)) {y[i] <- eval(parse(text = x[i]))}
-  data.frame(typename = x, typeoid = y)
+  within(data.frame(
+    typename = ls(name = .GlobalEnv, pat = "OID"),
+    stringsAsFactors = FALSE
+  ),
+  {
+    typeoid <- sapply(typename, get)
+  })
 ' language 'plr';
 
 CREATE OR REPLACE FUNCTION load_r_typenames()

--- a/plr--unpackaged--8.4.sql
+++ b/plr--unpackaged--8.4.sql
@@ -1,4 +1,4 @@
-/* plr/plr--unpackaged--8.3.0.17.sql */
+/* plr/plr--unpackaged--8.4.sql */
 
 ALTER EXTENSION plr ADD type plr_environ_type;
 ALTER EXTENSION plr ADD type r_typename;

--- a/plr.c
+++ b/plr.c
@@ -339,8 +339,12 @@ plr_init(void)
 	if (plr_pm_init_done)
 		return;
 
+#ifdef WIN32
+	r_home = get_R_HOME();
+#else
 	/* refuse to start if R_HOME is not defined */
 	r_home = getenv("R_HOME");
+#endif
 	if (r_home == NULL)
 	{
 		size_t		rh_len = strlen(R_HOME_DEFAULT);

--- a/plr.c
+++ b/plr.c
@@ -110,9 +110,11 @@ int R_SignalHandlers = 1;  /* Exposed in R_interface.h */
 #define SPI_CURSOR_CLOSE_CMD \
 			"pg.spi.cursor_close<-function(cursor) " \
 			"{.Call(\"plr_SPI_cursor_close\",cursor)}"
+#if CATALOG_VERSION_NO < 201811201
 #define SPI_LASTOID_CMD \
 			"pg.spi.lastoid <-function() " \
 			"{.Call(\"plr_SPI_lastoid\")}"
+#endif
 #define SPI_DBDRIVER_CMD \
 			"dbDriver <-function(db_name)\n" \
 			"{return(NA)}"
@@ -436,7 +438,9 @@ plr_load_builtins(Oid funcid)
 		SPI_CURSOR_FETCH_CMD,
 		SPI_CURSOR_MOVE_CMD,
 		SPI_CURSOR_CLOSE_CMD,
+#if CATALOG_VERSION_NO < 201811201
 		SPI_LASTOID_CMD,
+#endif
 		SPI_DBDRIVER_CMD,
 		SPI_DBCONN_CMD,
 		SPI_DBSENDQUERY_CMD,

--- a/plr.control
+++ b/plr.control
@@ -1,5 +1,5 @@
 # plr extension
 comment = 'load R interpreter and execute R script from within a database'
-default_version = '8.3.0.18'
+default_version = '8.4'
 module_pathname = '$libdir/plr'
 relocatable = true

--- a/plr.h
+++ b/plr.h
@@ -33,7 +33,7 @@
 #ifndef PLR_H
 #define PLR_H
 
-#define PLR_VERSION		"08.03.00.18"
+#define PLR_VERSION		"08.04"
 
 #include "postgres.h"
 

--- a/plr.h
+++ b/plr.h
@@ -506,60 +506,60 @@ typedef struct plr_hashent
 extern int Rf_initEmbeddedR(int argc, char **argv);
 
 /* PL/R language handler */
-extern Datum plr_call_handler(PG_FUNCTION_ARGS);
-extern void PLR_CLEANUP;
-extern void plr_init(void);
-extern void plr_load_modules(void);
-extern void load_r_cmd(const char *cmd);
-extern SEXP call_r_func(SEXP fun, SEXP rargs);
+PGDLLEXPORT Datum plr_call_handler(PG_FUNCTION_ARGS);
+PGDLLEXPORT void PLR_CLEANUP;
+PGDLLEXPORT void plr_init(void);
+PGDLLEXPORT void plr_load_modules(void);
+PGDLLEXPORT void load_r_cmd(const char *cmd);
+PGDLLEXPORT SEXP call_r_func(SEXP fun, SEXP rargs);
 
 /* argument and return value conversion functions */
-extern SEXP pg_scalar_get_r(Datum dvalue, Oid arg_typid, FmgrInfo arg_out_func);
-extern SEXP pg_array_get_r(Datum dvalue, FmgrInfo out_func, int typlen, bool typbyval, char typalign);
-extern SEXP pg_datum_array_get_r(Datum *elem_values, bool *elem_nulls, int numels, bool has_nulls,
+PGDLLEXPORT SEXP pg_scalar_get_r(Datum dvalue, Oid arg_typid, FmgrInfo arg_out_func);
+PGDLLEXPORT SEXP pg_array_get_r(Datum dvalue, FmgrInfo out_func, int typlen, bool typbyval, char typalign);
+PGDLLEXPORT SEXP pg_datum_array_get_r(Datum *elem_values, bool *elem_nulls, int numels, bool has_nulls,
 								 Oid element_type, FmgrInfo out_func, bool typbyval);
-extern SEXP pg_tuple_get_r_frame(int ntuples, HeapTuple *tuples, TupleDesc tupdesc);
-extern Datum r_get_pg(SEXP rval, plr_function *function, FunctionCallInfo fcinfo);
-extern Datum get_datum(SEXP rval, Oid typid, Oid typelem, FmgrInfo in_func, bool *isnull);
-extern Datum get_scalar_datum(SEXP rval, Oid result_typ, FmgrInfo result_in_func, bool *isnull);
+PGDLLEXPORT SEXP pg_tuple_get_r_frame(int ntuples, HeapTuple *tuples, TupleDesc tupdesc);
+PGDLLEXPORT Datum r_get_pg(SEXP rval, plr_function *function, FunctionCallInfo fcinfo);
+PGDLLEXPORT Datum get_datum(SEXP rval, Oid typid, Oid typelem, FmgrInfo in_func, bool *isnull);
+PGDLLEXPORT Datum get_scalar_datum(SEXP rval, Oid result_typ, FmgrInfo result_in_func, bool *isnull);
 
 /* Postgres support functions installed into the R interpreter */
-extern void throw_pg_notice(const char **msg);
-extern SEXP plr_quote_literal(SEXP rawstr);
-extern SEXP plr_quote_ident(SEXP rawstr);
-extern SEXP plr_SPI_exec(SEXP rsql);
-extern SEXP plr_SPI_prepare(SEXP rsql, SEXP rargtypes);
-extern SEXP plr_SPI_execp(SEXP rsaved_plan, SEXP rargvalues);
-extern SEXP plr_SPI_cursor_open(SEXP cursor_name_arg,SEXP rsaved_plan, SEXP rargvalues);
-extern SEXP plr_SPI_cursor_fetch(SEXP cursor_in,SEXP forward_in, SEXP rows_in);
-extern void plr_SPI_cursor_close(SEXP cursor_in);
-extern void plr_SPI_cursor_move(SEXP cursor_in, SEXP forward_in, SEXP rows_in);
-extern SEXP plr_SPI_lastoid(void);
-extern void throw_r_error(const char **msg);
+PGDLLEXPORT void throw_pg_notice(const char **msg);
+PGDLLEXPORT SEXP plr_quote_literal(SEXP rawstr);
+PGDLLEXPORT SEXP plr_quote_ident(SEXP rawstr);
+PGDLLEXPORT SEXP plr_SPI_exec(SEXP rsql);
+PGDLLEXPORT SEXP plr_SPI_prepare(SEXP rsql, SEXP rargtypes);
+PGDLLEXPORT SEXP plr_SPI_execp(SEXP rsaved_plan, SEXP rargvalues);
+PGDLLEXPORT SEXP plr_SPI_cursor_open(SEXP cursor_name_arg,SEXP rsaved_plan, SEXP rargvalues);
+PGDLLEXPORT SEXP plr_SPI_cursor_fetch(SEXP cursor_in,SEXP forward_in, SEXP rows_in);
+PGDLLEXPORT void plr_SPI_cursor_close(SEXP cursor_in);
+PGDLLEXPORT void plr_SPI_cursor_move(SEXP cursor_in, SEXP forward_in, SEXP rows_in);
+PGDLLEXPORT SEXP plr_SPI_lastoid(void);
+PGDLLEXPORT void throw_r_error(const char **msg);
 
 /* Postgres callable functions useful in conjunction with PL/R */
-extern Datum plr_version(PG_FUNCTION_ARGS);
-extern Datum reload_plr_modules(PG_FUNCTION_ARGS);
-extern Datum install_rcmd(PG_FUNCTION_ARGS);
-extern Datum plr_array_push(PG_FUNCTION_ARGS);
-extern Datum plr_array(PG_FUNCTION_ARGS);
-extern Datum plr_array_accum(PG_FUNCTION_ARGS);
-extern Datum plr_environ(PG_FUNCTION_ARGS);
-extern Datum plr_set_rhome(PG_FUNCTION_ARGS);
-extern Datum plr_unset_rhome(PG_FUNCTION_ARGS);
-extern Datum plr_set_display(PG_FUNCTION_ARGS);
-extern Datum plr_get_raw(PG_FUNCTION_ARGS);
+PGDLLEXPORT Datum plr_version(PG_FUNCTION_ARGS);
+PGDLLEXPORT Datum reload_plr_modules(PG_FUNCTION_ARGS);
+PGDLLEXPORT Datum install_rcmd(PG_FUNCTION_ARGS);
+PGDLLEXPORT Datum plr_array_push(PG_FUNCTION_ARGS);
+PGDLLEXPORT Datum plr_array(PG_FUNCTION_ARGS);
+PGDLLEXPORT Datum plr_array_accum(PG_FUNCTION_ARGS);
+PGDLLEXPORT Datum plr_environ(PG_FUNCTION_ARGS);
+PGDLLEXPORT Datum plr_set_rhome(PG_FUNCTION_ARGS);
+PGDLLEXPORT Datum plr_unset_rhome(PG_FUNCTION_ARGS);
+PGDLLEXPORT Datum plr_set_display(PG_FUNCTION_ARGS);
+PGDLLEXPORT Datum plr_get_raw(PG_FUNCTION_ARGS);
 
 /* Postgres backend support functions */
-extern void compute_function_hashkey(FunctionCallInfo fcinfo,
+PGDLLEXPORT void compute_function_hashkey(FunctionCallInfo fcinfo,
 									 Form_pg_proc procStruct,
 									 plr_func_hashkey *hashkey);
-extern void plr_HashTableInit(void);
-extern plr_function *plr_HashTableLookup(plr_func_hashkey *func_key);
-extern void plr_HashTableInsert(plr_function *function,
+PGDLLEXPORT void plr_HashTableInit(void);
+PGDLLEXPORT plr_function *plr_HashTableLookup(plr_func_hashkey *func_key);
+PGDLLEXPORT void plr_HashTableInsert(plr_function *function,
 								plr_func_hashkey *func_key);
-extern void plr_HashTableDelete(plr_function *function);
-extern char *get_load_self_ref_cmd(Oid funcid);
-extern void perm_fmgr_info(Oid functionId, FmgrInfo *finfo);
+PGDLLEXPORT void plr_HashTableDelete(plr_function *function);
+PGDLLEXPORT char *get_load_self_ref_cmd(Oid funcid);
+PGDLLEXPORT void perm_fmgr_info(Oid functionId, FmgrInfo *finfo);
 
 #endif   /* PLR_H */

--- a/plr.sql.in
+++ b/plr.sql.in
@@ -48,10 +48,13 @@ REVOKE EXECUTE ON FUNCTION plr_environ() FROM PUBLIC;
 CREATE TYPE r_typename AS (typename text, typeoid oid);
 CREATE OR REPLACE FUNCTION r_typenames()
 RETURNS SETOF r_typename AS '
-  x <- ls(name = .GlobalEnv, pat = "OID")
-  y <- vector()
-  for (i in 1:length(x)) {y[i] <- eval(parse(text = x[i]))}
-  data.frame(typename = x, typeoid = y)
+  within(data.frame(
+    typename = ls(name = .GlobalEnv, pat = "OID"),
+    stringsAsFactors = FALSE
+  ),
+  {
+    typeoid <- sapply(typename, get)
+  })
 ' language 'plr';
 
 CREATE OR REPLACE FUNCTION load_r_typenames()

--- a/plr.vcxproj
+++ b/plr.vcxproj
@@ -1,0 +1,101 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <VCProjectVersion>15.0</VCProjectVersion>
+    <ProjectGuid>{CC739A29-855A-4FB0-B859-ECD0EBC538C5}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>plr</RootNamespace>
+    <PlatformToolset>v140</PlatformToolset>
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <CustomBuildBeforeTargets>Link</CustomBuildBeforeTargets>
+    <WholeProgramOptimization Condition="'$(Configuration)'=='Release'">true</WholeProgramOptimization>
+    <rbin Condition="$(Platform)=='Win32'">i386</rbin>
+    <rbin Condition="$(Platform)=='x64'">x64</rbin>
+    <pf>$(ProgramFiles)</pf>
+    <pf Condition="$(Platform)=='x64'">$(ProgramW6432)</pf>
+  </PropertyGroup>
+  <PropertyGroup Label="UserMacros">
+    <pgversion Condition="$(pgversion) == ''">9.6</pgversion>
+    <mingw Condition="$(mingw) == ''">C:\RTools\mingw_</mingw>
+    <pgroot Condition="$(pgroot)==''">$(pf)\PostgreSQL\$(pgversion)</pgroot>
+    <rversion Condition="$(rversion)==''">3.5.1</rversion>
+    <r_home Condition="$(R_HOME)==''">C:\Program Files\R\R-$(rversion)</r_home>
+    <sed Condition="$(sed)==''">$(mingw)\..\bin\sed</sed>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <PropertyGroup>
+    <IncludePath>$(R_HOME)\include;$(pgroot)\include;$(pgroot)\include\server;$(pgroot)\include\server\port\win32;$(pgroot)\include\server\port\win32_msvc;$(IncludePath)</IncludePath>
+    <LibraryPath>$(pgroot)\lib;$(LibraryPath)</LibraryPath>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)'=='Debug'">
+    <LinkIncremental>true</LinkIncremental>
+  </PropertyGroup>
+  <ItemDefinitionGroup>
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <CompileAs>CompileAsC</CompileAs>
+      <ExceptionHandling>false</ExceptionHandling>
+      <EnableEnhancedInstructionSet Condition="$(PlatformToolset)!='Windows7.1SDK'">AdvancedVectorExtensions2</EnableEnhancedInstructionSet>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <PreprocessorDefinitions>Win32;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions Condition="$(pgversion)=='9.3'">WIN32;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Condition="$(Configuration)=='Release'">
+      <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <InlineFunctionExpansion>AnySuitable</InlineFunctionExpansion>
+      <StringPooling>true</StringPooling>
+    </ClCompile>
+    <ClCompile Condition="$(Configuration)=='Debug'">
+      <Optimization>Disabled</Optimization>
+      <MinimalRebuild>true</MinimalRebuild>
+      <BrowseInformation Condition="$(CI)==''">true</BrowseInformation>
+      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+    </ClCompile>
+    <Link>
+      <AdditionalDependencies>R$(PlatformArchitecture).lib;postgres.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <FullProgramDatabaseFile>true</FullProgramDatabaseFile>
+    </Link>
+    <CustomBuildStep>
+      <Command>$(mingw)$(PlatformArchitecture)\bin\gendef.exe - "$(R_HOME)\bin\$(rbin)\R.dll" &gt; R$(PlatformArchitecture).def
+lib /def:R$(PlatformArchitecture).def /out:R$(PlatformArchitecture).lib /MACHINE:$(PlatformTarget)
+if "%CI%"=="" ( if not exist data "$(pgroot)\bin\initdb" -D data )
+if not exist plr.sql "$(sed)" -e "s#MODULE_PATHNAME#$libdir/plr#" plr.sql.in &gt; plr.sql
+</Command>
+      <Outputs>R$(PlatformArchitecture).lib</Outputs>
+      <Message>Generate R import library</Message>
+    </CustomBuildStep>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="pg_backend_support.c" />
+    <ClCompile Include="pg_conversion.c" />
+    <ClCompile Include="pg_rsupport.c" />
+    <ClCompile Include="pg_userfuncs.c" />
+    <ClCompile Include="plr.c" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="plr.h" />
+  </ItemGroup>
+</Project>

--- a/plr.vcxproj
+++ b/plr.vcxproj
@@ -74,17 +74,17 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>R$(PlatformArchitecture).lib;postgres.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>R$(PlatformTarget).lib;postgres.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <FullProgramDatabaseFile>true</FullProgramDatabaseFile>
     </Link>
     <CustomBuildStep>
-      <Command>$(mingw)$(PlatformArchitecture)\bin\gendef.exe - "$(R_HOME)\bin\$(rbin)\R.dll" &gt; R$(PlatformArchitecture).def
-lib /def:R$(PlatformArchitecture).def /out:R$(PlatformArchitecture).lib /MACHINE:$(PlatformTarget)
+      <Command>$(mingw)$(PlatformArchitecture)\bin\gendef.exe - "$(R_HOME)\bin\$(rbin)\R.dll" &gt; R$(PlatformTarget).def
+lib /def:R$(PlatformTarget).def /out:R$(PlatformTarget).lib /MACHINE:$(PlatformTarget)
 if "%CI%"=="" ( if not exist data "$(pgroot)\bin\initdb" -D data )
 if not exist plr.sql "$(sed)" -e "s#MODULE_PATHNAME#$libdir/plr#" plr.sql.in &gt; plr.sql
 </Command>
-      <Outputs>R$(PlatformArchitecture).lib</Outputs>
+      <Outputs>R$(PlatformTarget).lib</Outputs>
       <Message>Generate R import library</Message>
     </CustomBuildStep>
   </ItemDefinitionGroup>

--- a/plr.vcxproj.user
+++ b/plr.vcxproj.user
@@ -1,0 +1,17 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup Condition="'$(Configuration)'=='Debug'">
+    <OutDir>$(pgroot)\lib\</OutDir>
+    <TargetPath>$(pgroot)\lib\$(TargetName)$(TargetExt)</TargetPath>
+    <pgdata Condition="$(pgdata)==''">$(ProjectDir)\data</pgdata>
+    <LocalDebuggerCommand>$(pgroot)\bin\postgres.exe</LocalDebuggerCommand>
+    <LocalDebuggerCommandArguments>-p 5433 -D data</LocalDebuggerCommandArguments>
+    <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
+    <LocalDebuggerDebuggerType>NativeOnly</LocalDebuggerDebuggerType>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)'=='Debug'">
+    <Link>
+      <ProgramDatabaseFile>$(OutDir)\..\symbols\$(TargetName).pdb</ProgramDatabaseFile>
+    </Link>
+  </ItemDefinitionGroup>
+</Project>

--- a/sql/bad_fun.sql
+++ b/sql/bad_fun.sql
@@ -1,0 +1,11 @@
+-- should error out but should not crash PG
+CREATE OR REPLACE
+FUNCTION r_bad_fun()
+RETURNS int4 AS
+$BODY$
+  deadbeef <- function(,bad) {}
+  42
+$BODY$
+LANGUAGE plr;
+
+SELECT r_bad_fun();

--- a/userguide.md
+++ b/userguide.md
@@ -162,6 +162,11 @@ ldconfig. Refer toman ldconfigor its equivalent for your system.
 beforethe postmaster is started. Otherwise PL/R will refuse to load. See plr_environ(), which allows
 examination of the environment available to the PostgreSQL postmaster process.
 
+**Tip:** On Win32 platform, R will consider a registry entry created by R installer if
+it fails to find R_HOME environment variable. If you accepted installer defaults,
+there is no need to set R_HOME on this platform. Be careful removing older version of R as it may take
+away InstallPath entry away from HKLM\SOFTWARE\R-core\R.
+
 
 ## Functions and Arguments <a name="functions"></a>
 


### PR DESCRIPTION
Many Windows users get PG & R from installers. Also sooner or later one likely will have RTools installed as well to build some R packages from source. It is inconvenient to install everything from git just to get PL/R built. Moreover it is easier to upgrade R rather than PG thus those unlucky ones with older PG have to either use older R and PL/R to be able to use it, or build everything from source. This PR allows to build, install, and debug PL/R with MS Visual Studio much faster provided PG, R, and RTools are already installed. Also this PR has Appveyor changes to build PL/R for PGs from 9.4 up to 11 for both x86 and x64 versions.

I understand the importance of traditional build routine for potential inclusion with PG. I am willing to try to adjust the Appveyor.yml to include traditional one as well.

P.S. One would need to change write permissions to pgroot\lib and pgroot\share to ease debugging (or run MS Visual Studio as Administrator).

P.P.S. I will rebase fixups before merge if generally approved.