### PR TITLE
Fix: as of version 12 arguments to functions are passed differently

### DIFF
--- a/expected/plr.out
+++ b/expected/plr.out
@@ -267,7 +267,7 @@ select sprintf('%s is %s feet tall', 'Sven', '7');
 --
 -- test aggregates
 --
-create table foo(f0 int, f1 text, f2 float8) with oids;
+create table foo(f0 int, f1 text, f2 float8); 
 insert into foo values(1,'cat1',1.21);
 insert into foo values(2,'cat1',1.24);
 insert into foo values(3,'cat1',1.18);
@@ -277,6 +277,7 @@ insert into foo values(6,'cat2',1.15);
 insert into foo values(7,'cat2',1.26);
 insert into foo values(8,'cat2',1.32);
 insert into foo values(9,'cat2',1.30);
+insert into foo values(10,'cat2',1.31);
 create or replace function r_median(_float8) returns float as 'median(arg1)' language 'plr';
 select r_median('{1.23,1.31,1.42,1.27}'::_float8);
  r_median 
@@ -289,7 +290,7 @@ select f1, median(f2) from foo group by f1 order by f1;
   f1  | median 
 ------+--------
  cat1 |   1.21
- cat2 |   1.28
+ cat2 |    1.3
 (2 rows)
 
 create or replace function r_gamma(_float8) returns float as 'gamma(arg1)' language 'plr';
@@ -412,7 +413,7 @@ select test_dta2();
 -- generates expected error
 create or replace function test_dia1() returns int[] as 'as.data.frame(array(letters[1:10], c(2,5)))' language 'plr';
 select test_dia1() as error;
-ERROR:  invalid input syntax for integer: "a"
+ERROR:  invalid input syntax for type integer: "a"
 CONTEXT:  In PL/R function test_dia1
 create or replace function test_dtup() returns setof record as 'data.frame(letters[1:10],1:10)' language 'plr';
 select * from test_dtup() as t(f1 text, f2 int);
@@ -613,13 +614,6 @@ select * from test_spi_execp('sp','oid','text') as t(typeid oid, typename name);
      25 | text
      26 | oid
 (2 rows)
-
-create or replace function test_spi_lastoid(text) returns text as 'pg.spi.exec(arg1); pg.spi.lastoid()/pg.spi.lastoid()' language 'plr';
-select test_spi_lastoid('insert into foo values(10,''cat3'',3.333)') as "ONE";
- ONE 
------
- 1
-(1 row)
 
 --
 -- test NULL handling

--- a/pg_conversion.c
+++ b/pg_conversion.c
@@ -2031,7 +2031,7 @@ get_frame_tuplestore(SEXP rval,
 						}
 						else
 						{
-							FunctionCallInfoData	fake_fcinfo;
+							FunctionCallInfoBaseData	fake_fcinfo;
 							FmgrInfo				flinfo;
 							Datum					dvalue;
 							
@@ -2043,8 +2043,8 @@ get_frame_tuplestore(SEXP rval,
 							fake_fcinfo.resultinfo = NULL;
 							fake_fcinfo.isnull = false;
 							fake_fcinfo.nargs = 1;
-							fake_fcinfo.arg[0] = arr_datum;
-							fake_fcinfo.argnull[0] = false;
+							fake_fcinfo.args[0].value = arr_datum;
+							fake_fcinfo.args[0].isnull = false;
 							dvalue = (*array_out)(&fake_fcinfo);
 							if (fake_fcinfo.isnull)
 								values[j] = NULL;

--- a/plr.c
+++ b/plr.c
@@ -183,7 +183,7 @@ static plr_function *do_compile(FunctionCallInfo fcinfo,
 								plr_func_hashkey *hashkey);
 static void plr_protected_parse(void* data);
 static SEXP plr_parse_func_body(const char *body);
-static SEXP plr_convertargs(plr_function *function, Datum *arg, bool *argnull, FunctionCallInfo fcinfo);
+static SEXP plr_convertargs(plr_function *function, NullableDatum *args, FunctionCallInfo fcinfo);
 static void plr_error_callback(void *arg);
 static Oid getNamespaceOidFromFunctionOid(Oid fnOid);
 static bool haveModulesTable(Oid nspOid);
@@ -593,8 +593,7 @@ plr_trigger_handler(PG_FUNCTION_ARGS)
 	SEXP			rargs;
 	SEXP			rvalue;
 	Datum			retval;
-	Datum			arg[FUNC_MAX_ARGS];
-	bool			argnull[FUNC_MAX_ARGS];
+	NullableDatum  args[sizeof(NullableDatum) * FUNC_MAX_ARGS];
 	TriggerData	   *trigdata = (TriggerData *) fcinfo->context;
 	TupleDesc		tupdesc = trigdata->tg_relation->rd_att;
 	Datum		   *dvalues;
@@ -624,60 +623,61 @@ plr_trigger_handler(PG_FUNCTION_ARGS)
 	 * are mostly hardwired in advance
 	 */
 	/* first is trigger name */
-	arg[0] = DirectFunctionCall1(textin,
+	args[0].value = DirectFunctionCall1(textin,
 				 CStringGetDatum(trigdata->tg_trigger->tgname));
-	argnull[0] = false;
+	args[0].isnull = false;
 
 	/* second is trigger relation oid */
-	arg[1] = ObjectIdGetDatum(trigdata->tg_relation->rd_id);
-	argnull[1] = false;
+	args[1].value = ObjectIdGetDatum(trigdata->tg_relation->rd_id);
+	args[1].isnull = false;
 
 	/* third is trigger relation name */
-	arg[2] = DirectFunctionCall1(textin,
+	args[2].value = DirectFunctionCall1(textin,
 				 CStringGetDatum(get_rel_name(trigdata->tg_relation->rd_id)));
-	argnull[2] = false;
+	args[2].isnull = false;
 
 	/* fourth is when trigger fired, i.e. BEFORE or AFTER */
 	if (TRIGGER_FIRED_BEFORE(trigdata->tg_event))
-		arg[3] = DirectFunctionCall1(textin,
+		args[3].value = DirectFunctionCall1(textin,
 				 CStringGetDatum("BEFORE"));
 	else if (TRIGGER_FIRED_AFTER(trigdata->tg_event))
-		arg[3] = DirectFunctionCall1(textin,
+		args[3].value = DirectFunctionCall1(textin,
 				 CStringGetDatum("AFTER"));
 	else
 		/* internal error */
 		elog(ERROR, "unrecognized tg_event");
-	argnull[3] = false;
+	args[3].isnull = false;
+
 
 	/*
 	 * fifth is level trigger fired, i.e. ROW or STATEMENT
 	 * sixth is operation that fired trigger, i.e. INSERT, UPDATE, or DELETE
-	 * seventh is NEW, eigth is OLD
+	 * seventh is NEW, eighth is OLD
 	 */
 	if (TRIGGER_FIRED_FOR_STATEMENT(trigdata->tg_event))
 	{
-		arg[4] = DirectFunctionCall1(textin,
+		args[4].value = DirectFunctionCall1(textin,
 				 CStringGetDatum("STATEMENT"));
 
 		if (TRIGGER_FIRED_BY_INSERT(trigdata->tg_event))
-			arg[5] = DirectFunctionCall1(textin, CStringGetDatum("INSERT"));
+			args[5].value = DirectFunctionCall1(textin, CStringGetDatum("INSERT"));
 		else if (TRIGGER_FIRED_BY_DELETE(trigdata->tg_event))
-			arg[5] = DirectFunctionCall1(textin, CStringGetDatum("DELETE"));
+			args[5].value = DirectFunctionCall1(textin, CStringGetDatum("DELETE"));
 		else if (TRIGGER_FIRED_BY_UPDATE(trigdata->tg_event))
-			arg[5] = DirectFunctionCall1(textin, CStringGetDatum("UPDATE"));
+			args[5].value = DirectFunctionCall1(textin, CStringGetDatum("UPDATE"));
 		else
 			/* internal error */
 			elog(ERROR, "unrecognized tg_event");
 
-		arg[6] = (Datum) 0;
-		argnull[6] = true;
+		args[6].value = (Datum) 0;
+		args[6].isnull = true;
 
-		arg[7] = (Datum) 0;
-		argnull[7] = true;
+		args[7].value = (Datum) 0;
+		args[7].isnull = true;
 	}
 	else if (TRIGGER_FIRED_FOR_ROW(trigdata->tg_event))
 	{
-		arg[4] = DirectFunctionCall1(textin,
+		args[4].value = DirectFunctionCall1(textin,
 				 CStringGetDatum("ROW"));
 
 		if (TRIGGER_FIRED_BY_INSERT(trigdata->tg_event))
@@ -694,8 +694,9 @@ plr_trigger_handler(PG_FUNCTION_ARGS)
 		/* internal error */
 		elog(ERROR, "unrecognized tg_event");
 
-	argnull[4] = false;
-	argnull[5] = false;
+	args[4].isnull = false;
+	args[5].isnull = false;
+
 
 	/*
 	 * finally, ninth argument is a text array of trigger arguments
@@ -709,8 +710,8 @@ plr_trigger_handler(PG_FUNCTION_ARGS)
 	array = construct_md_array(dvalues, NULL, ndims, dims, lbs,
 								TEXTOID, -1, false, 'i');
 
-	arg[8] = PointerGetDatum(array);
-	argnull[8] = false;
+	args[8].value = PointerGetDatum(array);
+	args[8].isnull = false;
 
 	/*
 	 * All done building args; from this point it is just like
@@ -720,7 +721,7 @@ plr_trigger_handler(PG_FUNCTION_ARGS)
 	PROTECT(fun = function->fun);
 
 	/* Convert all call arguments */
-	PROTECT(rargs = plr_convertargs(function, arg, argnull, fcinfo));
+	PROTECT(rargs = plr_convertargs(function, args, fcinfo));
 
 	/* Call the R function */
 	PROTECT(rvalue = call_r_func(fun, rargs));
@@ -758,7 +759,7 @@ plr_func_handler(PG_FUNCTION_ARGS)
 	PROTECT(fun = function->fun);
 
 	/* Convert all call arguments */
-	PROTECT(rargs = plr_convertargs(function, fcinfo->arg, fcinfo->argnull, fcinfo));
+	PROTECT(rargs = plr_convertargs(function, fcinfo->args, fcinfo));
 
 	/* Call the R function */
 	PROTECT(rvalue = call_r_func(fun, rargs));
@@ -1480,7 +1481,7 @@ call_r_func(SEXP fun, SEXP rargs)
 }
 
 static SEXP
-plr_convertargs(plr_function *function, Datum *arg, bool *argnull, FunctionCallInfo fcinfo)
+plr_convertargs(plr_function *function, NullableDatum *args, FunctionCallInfo fcinfo)
 {
 	int		i;
 	int		m = 1;
@@ -1517,7 +1518,7 @@ plr_convertargs(plr_function *function, Datum *arg, bool *argnull, FunctionCallI
 		if (!function->iswindow)
 		{
 #endif
-			if (argnull[i])
+			if (args[i].isnull)
 			{
 				/* fast track for null arguments */
 				PROTECT(el = R_NilValue);
@@ -1530,7 +1531,7 @@ plr_convertargs(plr_function *function, Datum *arg, bool *argnull, FunctionCallI
 			else if (function->arg_elem[i] == InvalidOid)
 			{
 				/* for scalar args, convert to a one row vector */
-				Datum		dvalue = arg[i];
+				Datum		dvalue = args[i].value;
 				Oid			arg_typid = function->arg_typid[i];
 				FmgrInfo	arg_out_func = function->arg_out_func[i];
 
@@ -1539,7 +1540,7 @@ plr_convertargs(plr_function *function, Datum *arg, bool *argnull, FunctionCallI
 			else
 			{
 				/* better be a pg array arg, convert to a multi-row vector */
-				Datum		dvalue = (Datum) PG_DETOAST_DATUM(arg[i]);
+				Datum		dvalue = (Datum) PG_DETOAST_DATUM(args[i].value);
 				FmgrInfo	out_func = function->arg_elem_out_func[i];
 				int			typlen = function->arg_elem_typlen[i];
 				bool		typbyval = function->arg_elem_typbyval[i];

--- a/plr.h
+++ b/plr.h
@@ -319,51 +319,51 @@ extern void R_RunExitFinalizers(void);
 	HeapTupleHeader	dtrigtup
 #define SET_INSERT_ARGS_567 \
 	do { \
-		arg[5] = DirectFunctionCall1(textin, CStringGetDatum("INSERT")); \
+		args[5].value = DirectFunctionCall1(textin, CStringGetDatum("INSERT")); \
 		tup = trigdata->tg_trigtuple; \
 		dtrigtup = (HeapTupleHeader) palloc(tup->t_len); \
 		memcpy((char *) dtrigtup, (char *) tup->t_data, tup->t_len); \
 		HeapTupleHeaderSetDatumLength(dtrigtup, tup->t_len); \
 		HeapTupleHeaderSetTypeId(dtrigtup, tupdesc->tdtypeid); \
 		HeapTupleHeaderSetTypMod(dtrigtup, tupdesc->tdtypmod); \
-		arg[6] = PointerGetDatum(dtrigtup); \
-		argnull[6] = false; \
-		arg[7] = (Datum) 0; \
-		argnull[7] = true; \
+		args[6].value = PointerGetDatum(dtrigtup); \
+		args[6].isnull = false; \
+		args[7].value = (Datum) 0; \
+		args[7].isnull = true; \
 	} while (0)
 #define SET_DELETE_ARGS_567 \
 	do { \
-		arg[5] = DirectFunctionCall1(textin, CStringGetDatum("DELETE")); \
-		arg[6] = (Datum) 0; \
-		argnull[6] = true; \
+		args[5].value = DirectFunctionCall1(textin, CStringGetDatum("DELETE")); \
+		args[6].value = (Datum) 0; \
+		args[6].isnull = true; \
 		tup = trigdata->tg_trigtuple; \
 		dtrigtup = (HeapTupleHeader) palloc(tup->t_len); \
 		memcpy((char *) dtrigtup, (char *) tup->t_data, tup->t_len); \
 		HeapTupleHeaderSetDatumLength(dtrigtup, tup->t_len); \
 		HeapTupleHeaderSetTypeId(dtrigtup, tupdesc->tdtypeid); \
 		HeapTupleHeaderSetTypMod(dtrigtup, tupdesc->tdtypmod); \
-		arg[7] = PointerGetDatum(dtrigtup); \
-		argnull[7] = false; \
+		args[7].value = PointerGetDatum(dtrigtup); \
+		args[7].isnull = false; \
 	} while (0)
 #define SET_UPDATE_ARGS_567 \
 	do { \
-		arg[5] = DirectFunctionCall1(textin, CStringGetDatum("UPDATE")); \
+		args[5].value = DirectFunctionCall1(textin, CStringGetDatum("UPDATE")); \
 		tup = trigdata->tg_newtuple; \
 		dnewtup = (HeapTupleHeader) palloc(tup->t_len); \
 		memcpy((char *) dnewtup, (char *) tup->t_data, tup->t_len); \
 		HeapTupleHeaderSetDatumLength(dnewtup, tup->t_len); \
 		HeapTupleHeaderSetTypeId(dnewtup, tupdesc->tdtypeid); \
 		HeapTupleHeaderSetTypMod(dnewtup, tupdesc->tdtypmod); \
-		arg[6] = PointerGetDatum(dnewtup); \
-		argnull[6] = false; \
+		args[6].value = PointerGetDatum(dnewtup); \
+		args[6].isnull = false; \
 		tup = trigdata->tg_trigtuple; \
 		dtrigtup = (HeapTupleHeader) palloc(tup->t_len); \
 		memcpy((char *) dtrigtup, (char *) tup->t_data, tup->t_len); \
 		HeapTupleHeaderSetDatumLength(dtrigtup, tup->t_len); \
 		HeapTupleHeaderSetTypeId(dtrigtup, tupdesc->tdtypeid); \
 		HeapTupleHeaderSetTypMod(dtrigtup, tupdesc->tdtypmod); \
-		arg[7] = PointerGetDatum(dtrigtup); \
-		argnull[7] = false; \
+		args[7].value = PointerGetDatum(dtrigtup); \
+		args[7].isnull = false; \
 	} while (0)
 #define CONVERT_TUPLE_TO_DATAFRAME \
 	do { \
@@ -371,7 +371,7 @@ extern void R_RunExitFinalizers(void);
 		int32		tupTypmod; \
 		TupleDesc	tupdesc; \
 		HeapTuple	tuple = palloc(sizeof(HeapTupleData)); \
-		HeapTupleHeader	tuple_hdr = DatumGetHeapTupleHeader(arg[i]); \
+		HeapTupleHeader	tuple_hdr = DatumGetHeapTupleHeader(args[i].value); \
 		tupType = HeapTupleHeaderGetTypeId(tuple_hdr); \
 		tupTypmod = HeapTupleHeaderGetTypMod(tuple_hdr); \
 		tupdesc = lookup_rowtype_tupdesc(tupType, tupTypmod); \

--- a/sql/plr.sql
+++ b/sql/plr.sql
@@ -129,7 +129,7 @@ select sprintf('%s is %s feet tall', 'Sven', '7');
 --
 -- test aggregates
 --
-create table foo(f0 int, f1 text, f2 float8) with oids;
+create table foo(f0 int, f1 text, f2 float8); 
 insert into foo values(1,'cat1',1.21);
 insert into foo values(2,'cat1',1.24);
 insert into foo values(3,'cat1',1.18);
@@ -139,6 +139,7 @@ insert into foo values(6,'cat2',1.15);
 insert into foo values(7,'cat2',1.26);
 insert into foo values(8,'cat2',1.32);
 insert into foo values(9,'cat2',1.30);
+insert into foo values(10,'cat2',1.31);
 
 create or replace function r_median(_float8) returns float as 'median(arg1)' language 'plr';
 select r_median('{1.23,1.31,1.42,1.27}'::_float8);
@@ -259,9 +260,6 @@ select test_spi_prep('select oid, typname from pg_type where typname = $1 or typ
 
 create or replace function test_spi_execp(text, text, text) returns setof record as 'pg.spi.execp(pg.reval(arg1), list(arg2,arg3))' language 'plr';
 select * from test_spi_execp('sp','oid','text') as t(typeid oid, typename name);
-
-create or replace function test_spi_lastoid(text) returns text as 'pg.spi.exec(arg1); pg.spi.lastoid()/pg.spi.lastoid()' language 'plr';
-select test_spi_lastoid('insert into foo values(10,''cat3'',3.333)') as "ONE";
 
 --
 -- test NULL handling


### PR DESCRIPTION
As of https://git.postgresql.org/gitweb/?p=postgresql.git;a=commit;f=src/backend/executor/functions.c;h=a9c35cf85ca1ff72f16f0f10d7ddee6e582b62b8
Arguments to functions are now passed in a  structure.
As well tables with oid's have been removed so we no longer test functions that get the last inserted oid

This patch fixes both

Will need a second pass to make this somewhat version independent 