### PR TITLE
Add support for pg custom type (tuple) arguments in window PL/R functions

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -163,7 +163,7 @@ test_script:
     $env:Outcome="Passed"
     $elapsed=(Measure-Command {
       pg_regress "$env:psqlopt=$env:pgroot\bin" --dbname=pl_regression plr `
-        bad_fun opt_window do out_args plr_transaction 2>&1 |
+        bad_fun opt_window do out_args plr_transaction opt_window_frame 2>&1 |
         %{ if ($_ -is [System.Management.Automation.ErrorRecord]) { $_.Exception.Message } else { $_ } } |
           Out-Default
       if ($LASTEXITCODE -ne 0) {

--- a/expected/opt_window.out
+++ b/expected/opt_window.out
@@ -1,5 +1,5 @@
 create or replace function fast_win(a int4, b bigint) returns bool AS $$
-  is.null(farg2) || pg.throwerror('Constants shall not be passes with the frame')
+##is.null(farg2) || pg.throwerror('Constants shall not be passes with the frame')
   identical(parent.frame(), .GlobalEnv) && pg.throwerror('Parent env is global')
   exists('plr_window_frame', parent.frame(), inherits=FALSE) || pg.throwerror('No window frame data found')
   a == farg1[prownum]

--- a/expected/opt_window_frame.out
+++ b/expected/opt_window_frame.out
@@ -1,0 +1,25 @@
+create type tt as (x int, y int[]);
+create or replace function fast_win_frame(r int, t tt) returns bool AS $$
+  identical(parent.frame(), .GlobalEnv) && pg.throwerror('Parent env is global')
+  exists('plr_window_frame', parent.frame(), inherits=FALSE) || pg.throwerror('No window frame data found')
+  r == farg2[[prownum,2]][3]
+$$ window language plr;
+select s.r, s.p, fast_win_frame(NULLIF(r,4), (s.r, s.q)) over w
+from (select r, r % 2 as p, array_fill(case when r=7 then 77 else r end, ARRAY[3]) as q from  generate_series(1,10) r) s
+window w as (partition by p order by r rows between unbounded preceding and unbounded following)
+order by s.r;
+ r  | p | fast_win_frame 
+----+---+----------------
+  1 | 1 | t
+  2 | 0 | t
+  3 | 1 | t
+  4 | 0 | 
+  5 | 1 | t
+  6 | 0 | t
+  7 | 1 | f
+  8 | 0 | t
+  9 | 1 | t
+ 10 | 0 | t
+(10 rows)
+
+

--- a/expected/opt_window_frame.out
+++ b/expected/opt_window_frame.out
@@ -1,5 +1,4 @@
-create type tt as (x int, y int[]);
-create or replace function fast_win_frame(r int, t tt) returns bool AS $$
+create or replace function fast_win_frame(r int, t record) returns bool AS $$
   identical(parent.frame(), .GlobalEnv) && pg.throwerror('Parent env is global')
   exists('plr_window_frame', parent.frame(), inherits=FALSE) || pg.throwerror('No window frame data found')
   r == farg2[[prownum,2]][3]

--- a/pg_conversion.c
+++ b/pg_conversion.c
@@ -34,7 +34,7 @@
  */
 #include "plr.h"
 
-static void pg_get_one_r(char *value, Oid arg_out_fn_oid, SEXP *obj,
+static void pg_get_one_r(char *value, Oid arg_out_fn_oid, SEXP obj,
 																int elnum);
 static SEXP get_r_vector(Oid typtype, int64 numels);
 static Datum get_trigger_tuple(SEXP rval, plr_function *function,
@@ -86,7 +86,7 @@ pg_scalar_get_r(Datum dvalue, Oid arg_typid, FmgrInfo arg_out_func)
 
 		/* get new vector of the appropriate type, length 1 */
 		PROTECT(result = get_r_vector(arg_typid, 1));
-		pg_get_one_r(value, arg_typid, &result, 0);
+		pg_get_one_r(value, arg_typid, result, 0);
 		UNPROTECT(1);
 	}
 	else
@@ -294,7 +294,7 @@ pg_array_get_r(Datum dvalue, FmgrInfo out_func, int typlen, bool typbyval, char 
 					 * Note that pg_get_one_r() replaces NULL values with
 					 * the NA value appropriate for the data type.
 					 */
-					pg_get_one_r(value, element_type, &result, idx);
+					pg_get_one_r(value, element_type, result, idx);
 					if (value != NULL)
 						pfree(value);
 				}
@@ -325,7 +325,9 @@ pg_array_get_r(Datum dvalue, FmgrInfo out_func, int typlen, bool typbyval, char 
 #ifdef HAVE_WINDOW_FUNCTIONS
 /*
  * Evaluate a window function's argument expression on a specified
- *		window frame, returning R array for the argno column in the frame
+ * window frame, returning either an array or an R dataframe
+ * for the argno column in the frame, depending on whether
+ * the argno argument is of composite type or not
  *
  * winobj: PostgreSQL window object handle
  * argno: argument number to evaluate (counted from 0)
@@ -334,78 +336,233 @@ pg_array_get_r(Datum dvalue, FmgrInfo out_func, int typlen, bool typbyval, char 
 SEXP
 pg_window_frame_get_r(WindowObject winobj, int argno, plr_function* function)
 {
-	/*
-	 * Loop through and convert each scalar value.
-	 * Use the converted values to build an R vector.
-	 */
-	SEXP		result;
-	int			numels = 0;
+	char		buf[256];
+	SEXP		result, v, names, row_names;
+	int64		i, numels = 0;
+	int			j, nc = 1, nc_effective = 1, df_colnum = 0;
+	Datum		dvalue;
+	bool		isnull, isout = false;
+	bool		isrel = function->arg_is_rel[argno];
 	Oid			element_type = function->arg_typid[argno];
 	FmgrInfo	out_func = function->arg_out_func[argno];
-	int64		totalrows = WinGetPartitionRowCount(winobj);
+	int64		nr = WinGetPartitionRowCount(winobj);
+	/* for tuple arguments */
+	HeapTuple	tuple;
+	HeapTupleHeader	tuple_hdr;
+	Oid			tupType;
+	int32		tupTypmod;
+	TupleDesc	tupdesc;
+	/* for array arguments */
+	Oid			typelem = function->arg_elem[argno];
+	int16		typlen;
+	bool		typbyval;
+	char		typdelim, typalign;
+	Oid			typoutput, typioparam;
+	FmgrInfo	outputproc;
+
+	if (nr < 1)
+		return R_NilValue;
 
 	/*
-	 * Get new vector of the appropriate type.
-	 * We presume unbound frame as a common use case in R.
-	 * If not, we will trim vector later.
+	 * Check to see if arg is an array type. typelem will be
+	 * InvalidOid instead of actual element type if the type is not a
+	 * varlena array.
 	 */
-	PROTECT(result = get_r_vector(element_type, totalrows));
+	if (!isrel && typelem != InvalidOid)
+	{
+		typlen = function->arg_elem_typlen[argno];
+		typbyval = function->arg_elem_typbyval[argno];
+		typalign = function->arg_elem_typalign[argno];
+		outputproc = function->arg_elem_out_func[argno];
+	}
 
-	/* Convert all values to their R form and build the vector */
+	if (isrel)
+	{
+		/*
+		 * Get current row for starters, setting mark
+		 * Need this to get tuple info in order to build an R dataframe
+		 */
+		dvalue = WinGetFuncArgInFrame(winobj, argno, 0, WINDOW_SEEK_HEAD,
+									  true, &isnull, &isout);
+		if (isout || isnull)
+			return R_NilValue;
+
+		/* Count non-dropped attributes so we can later ignore the dropped ones */
+		tuple_hdr = DatumGetHeapTupleHeader(dvalue);
+		tupType   = HeapTupleHeaderGetTypeId(tuple_hdr);
+		tupTypmod = HeapTupleHeaderGetTypMod(tuple_hdr);
+		tupdesc   = lookup_rowtype_tupdesc(tupType, tupTypmod);
+		nc		= tupdesc->natts;
+		for (j = 0, nc_effective = 0; j < nc; j++)
+		{
+			if (!TUPLE_DESC_ATTR(tupdesc,j)->attisdropped)
+				nc_effective++;
+		}
+		/*
+		 * Allocate the resulting data.frame initially as a list,
+		 * and also allocate a names vector for the column names.
+		 * If !isrel, then nc == nc_effective == 1, see below
+		 */
+		PROTECT(names = NEW_CHARACTER(nc_effective));
+	}
+	PROTECT(result = NEW_LIST(nc_effective));
+
 	for (;; numels++)
 	{
-		char	   *value;
-		bool		isnull;
-		Datum		dvalue;
-		bool		isout = false;
-		bool		set_mark = (0 == numels);
-
-		dvalue = WinGetFuncArgInFrame(winobj, argno, numels, WINDOW_SEEK_HEAD,
-			set_mark, &isnull, &isout);
+		dvalue = WinGetFuncArgInFrame(winobj, argno, numels, WINDOW_SEEK_HEAD, numels == 0, &isnull, &isout);
 
 		if (isout)
 			break;
 
-		switch (element_type)
+		if (isrel && !isnull)
 		{
-			case BOOLOID:
-				LOGICAL_DATA(result)[numels] = isnull ? NA_LOGICAL : DatumGetBool(dvalue);
-				break;
-			case INT8OID:
-				NUMERIC_DATA(result)[numels] = isnull ? NA_REAL : (double)DatumGetInt64(dvalue);
-				break;
-			case INT2OID:
-			case INT4OID:
-			case OIDOID:
-				INTEGER_DATA(result)[numels] = isnull ? NA_INTEGER : DatumGetInt32(dvalue);
-				break;
-			case FLOAT4OID:
-				NUMERIC_DATA(result)[numels] = isnull ? NA_REAL : DatumGetFloat4(dvalue);
-				break;
-			case FLOAT8OID:
-				NUMERIC_DATA(result)[numels] = isnull ? NA_REAL : DatumGetFloat8(dvalue);
-				break;
-			default:
-				value = isnull ? NULL : DatumGetCString(FunctionCall3(&out_func,
-															dvalue,
-															(Datum) 0,
-															Int32GetDatum(-1)));
+			/* Allocate new heaptuple for this row and set contents */
+			tuple = palloc(sizeof(HeapTupleData));
+			tuple_hdr = DatumGetHeapTupleHeader(dvalue);
+			tuple->t_len = HeapTupleHeaderGetDatumLength(tuple_hdr);
+			ItemPointerSetInvalid(&(tuple->t_self));
+			tuple->t_tableOid = InvalidOid;
+			tuple->t_data = tuple_hdr;
+		}
 
-				/*
-					* Note that pg_get_one_r() replaces NULL values with
-					* the NA value appropriate for the data type.
-					*/
-				pg_get_one_r(value, element_type, &result, numels);
+		for (df_colnum = 0, j = 0; j < nc; j++)
+		{
+			if (isrel)
+			{
+				/* ignore dropped attributes */
+				if (TUPLE_DESC_ATTR(tupdesc,j)->attisdropped)
+					continue;
+
+				/* set column names */
+				if (numels == 0)
+					SET_COLUMN_NAMES;
+
+				/* update column datatype oid and check for embedded array */
+				element_type = SPI_gettypeid(tupdesc, j + 1);
+				typelem = get_element_type(element_type);
+				if (typelem != InvalidOid)
+				{
+					get_type_io_data(typelem, IOFunc_output, &typlen, &typbyval, &typalign, &typdelim, &typioparam, &typoutput);
+					fmgr_info(typoutput, &outputproc);
+				}
+			}
+
+			if (numels == 0)
+			{
+				/* allocate new vector of the appropriate type and length */
+				if (typelem == InvalidOid)
+					/* dealing with scalars of element_type */
+					PROTECT(v = get_r_vector(element_type, nr));
+				else
+					/* dealing with arrays (containing typelem's) */
+					PROTECT(v = NEW_LIST(nr));
+				SET_VECTOR_ELT(result, df_colnum, v);
+				UNPROTECT(1);
+			}
+
+			v = VECTOR_ELT(result, df_colnum);
+			if (!isrel && typelem == InvalidOid)
+			{
+				/* scalar type */
+				char	   *value;
+				switch (element_type)
+				{
+					case BOOLOID:
+						LOGICAL_DATA(v)[numels] = isnull ? NA_LOGICAL : DatumGetBool(dvalue);
+						break;
+					case INT8OID:
+						NUMERIC_DATA(v)[numels] = isnull ? NA_REAL : (double)DatumGetInt64(dvalue);
+						break;
+					case INT2OID:
+					case INT4OID:
+					case OIDOID:
+						INTEGER_DATA(v)[numels] = isnull ? NA_INTEGER : DatumGetInt32(dvalue);
+						break;
+					case FLOAT4OID:
+						NUMERIC_DATA(v)[numels] = isnull ? NA_REAL : DatumGetFloat4(dvalue);
+						break;
+					case FLOAT8OID:
+						NUMERIC_DATA(v)[numels] = isnull ? NA_REAL : DatumGetFloat8(dvalue);
+						break;
+					default:
+						value = isnull ? NULL :
+							DatumGetCString(FunctionCall3(&out_func, dvalue, (Datum) 0, Int32GetDatum(-1)));
+						/*
+						 * Note that pg_get_one_r() replaces NULL values with
+						 * the NA value appropriate for the data type.
+						 */
+						pg_get_one_r(value, element_type, v, numels);
+						if (value != NULL)
+							pfree(value);
+				}
+			}
+			else if (isrel && typelem == InvalidOid)
+			{
+				char *value = isnull ? NULL : SPI_getvalue(tuple, tupdesc, j + 1);
+				pg_get_one_r(value, element_type, v, numels);
 				if (value != NULL)
 					pfree(value);
+			}
+			else /* typelem != InvalidOid, i.e.: */
+			{
+				/* array type (regardless of whether embedded in a tuple or not) */
+				SEXP		fldvec_elem;
+				Datum	   value = dvalue;
+				bool		isvaluenull = isnull;
+				if (isrel && !isnull)
+					value = SPI_getbinval(tuple, tupdesc, j + 1, &isvaluenull);
+
+				if (!isvaluenull)
+					PROTECT(fldvec_elem = pg_array_get_r(value, outputproc, typlen, typbyval, typalign));
+				else
+					PROTECT(fldvec_elem = R_NilValue);
+				SET_VECTOR_ELT(v, numels, fldvec_elem);
+				UNPROTECT(1);
+			}
+			df_colnum++;
+		}
+
+		if (isrel && !isnull)
+			pfree(tuple);
+	}
+
+	/* Resize all vectors from nr (rows in partition) down to numels (rows in frame) */
+	if (numels < nr)
+	{
+		for (df_colnum = 0, j = 0; j < nc; j++)
+		{
+			if (isrel && TUPLE_DESC_ATTR(tupdesc,j)->attisdropped)
+				continue;
+			v = VECTOR_ELT(result, df_colnum);
+			SET_VECTOR_ELT(result, df_colnum, SET_LENGTH(v, numels));
+			df_colnum++;
 		}
 	}
 
-	if (numels != totalrows)
-		SET_LENGTH(result, numels);
+	/* for non-tuple arguments return now */
+	if (!isrel)
+	{
+		v = VECTOR_ELT(result, 0);
+		UNPROTECT(1); /* result */
+		return v;
+	}
 
-	UNPROTECT(1);	/* result */
+	/* attach the column names */
+	setAttrib(result, R_NamesSymbol, names);
 
+	/* attach row names - basically just the row number, zero based */
+	PROTECT(row_names = allocVector(STRSXP, numels));
+	for (i = 0; i < numels; i++)
+	{
+		sprintf(buf, "%ld", i + 1);
+		SET_STRING_ELT(row_names, i, COPY_TO_USER_STRING(buf));
+	}
+	setAttrib(result, R_RowNamesSymbol, row_names);
+
+	/* finally, tell R we are a data.frame */
+	setAttrib(result, R_ClassSymbol, mkString("data.frame"));
+	ReleaseTupleDesc(tupdesc);
+	UNPROTECT(3); /* result, names, row-names */
 	return result;
 }
 #endif
@@ -499,7 +656,7 @@ pg_tuple_get_r_frame(int ntuples, HeapTuple *tuples, TupleDesc tupdesc)
 				char	   *value;
 
 				value = SPI_getvalue(tuples[i], tupdesc, j + 1);
-				pg_get_one_r(value, element_type, &fldvec, i);
+				pg_get_one_r(value, element_type, fldvec, i);
 			}
 			else
 			{
@@ -590,7 +747,7 @@ get_r_vector(Oid typtype, int64 numels)
  * given a single non-array pg value, convert to its R value representation
  */
 static void
-pg_get_one_r(char *value, Oid typtype, SEXP *obj, int elnum)
+pg_get_one_r(char *value, Oid typtype, SEXP obj, int elnum)
 {
 	switch (typtype)
 	{
@@ -599,9 +756,9 @@ pg_get_one_r(char *value, Oid typtype, SEXP *obj, int elnum)
 		case INT4OID:
 			/* 2 and 4 byte integer pgsql datatype => use R INTEGER */
 			if (value)
-				INTEGER_DATA(*obj)[elnum] = atoi(value);
+				INTEGER_DATA(obj)[elnum] = atoi(value);
 			else
-				INTEGER_DATA(*obj)[elnum] = NA_INTEGER;
+				INTEGER_DATA(obj)[elnum] = NA_INTEGER;
 			break;
 		case INT8OID:
 		case FLOAT4OID:
@@ -618,23 +775,23 @@ pg_get_one_r(char *value, Oid typtype, SEXP *obj, int elnum)
 				/* fixup for Visual Studio 2013, _MSC_VER == 1916*/
 				char *endptr = NULL;
 				const double el = strtod(value, &endptr);
-				NUMERIC_DATA(*obj)[elnum] = value==endptr ? R_NaN : el;
+				NUMERIC_DATA(obj)[elnum] = value==endptr ? R_NaN : el;
 			}
 			else
-				NUMERIC_DATA(*obj)[elnum] = NA_REAL;
+				NUMERIC_DATA(obj)[elnum] = NA_REAL;
 			break;
 		case BOOLOID:
 			if (value)
-				LOGICAL_DATA(*obj)[elnum] = ((*value == 't') ? 1 : 0);
+				LOGICAL_DATA(obj)[elnum] = ((*value == 't') ? 1 : 0);
 			else
-				LOGICAL_DATA(*obj)[elnum] = NA_LOGICAL;
+				LOGICAL_DATA(obj)[elnum] = NA_LOGICAL;
 			break;
 		default:
 			/* Everything else is defaulted to string */
 			if (value)
-				SET_STRING_ELT(*obj, elnum, COPY_TO_USER_STRING(value));
+				SET_STRING_ELT(obj, elnum, COPY_TO_USER_STRING(value));
 			else
-				SET_STRING_ELT(*obj, elnum, NA_STRING);
+				SET_STRING_ELT(obj, elnum, NA_STRING);
 	}
 }
 

--- a/plr.c
+++ b/plr.c
@@ -1345,22 +1345,7 @@ do_compile(FunctionCallInfo fcinfo,
 			}
 			typeStruct = (Form_pg_type) GETSTRUCT(typeTup);
 
-			/* Disallow pseudotype argument
-			 * note we already replaced ANYARRAY/ANYELEMENT
-			 */
-			if (typeStruct->typtype == 'p')
-			{
-				Oid		arg_typid = function->arg_typid[i];
-
-				xpfree(function->proname);
-				xpfree(function);
-				ereport(ERROR,
-						(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-						 errmsg("plr functions cannot take type %s",
-								format_type_be(arg_typid))));
-			}
-
-			if (typeStruct->typrelid != InvalidOid)
+			if (typeStruct->typrelid != InvalidOid || typeStruct->typtype == 'p')
 				function->arg_is_rel[i] = 1;
 			else
 				function->arg_is_rel[i] = 0;

--- a/plr.c
+++ b/plr.c
@@ -1673,7 +1673,7 @@ plr_convertargs(plr_function *function, Datum *arg, bool *argnull, FunctionCallI
 			else if (function->arg_is_rel[i])
 			{
 				/* for tuple args, convert to a one row data.frame */
-				CONVERT_TUPLE_TO_DATAFRAME;
+				CONVERT_TUPLE_TO_DATAFRAME(GET_ARG_VALUE(i));
 			}
 			else if (function->arg_elem[i] == InvalidOid)
 			{
@@ -1716,11 +1716,9 @@ plr_convertargs(plr_function *function, Datum *arg, bool *argnull, FunctionCallI
 			}
 			else if (function->arg_is_rel[i])
 			{
-				/* keep compiler quiet */
-				el = R_NilValue;
-
-				elog(ERROR, "Tuple arguments not supported in PL/R Window Functions");
-			}
+				/* for tuple args, convert to a one row data.frame */
+				CONVERT_TUPLE_TO_DATAFRAME(dvalue);
+ 			}
 			else if (function->arg_elem[i] == InvalidOid)
 			{
 				/* for scalar args, convert to a one row vector */
@@ -1757,16 +1755,16 @@ plr_convertargs(plr_function *function, Datum *arg, bool *argnull, FunctionCallI
 
 		if (plr_is_unbound_frame(winobj))
 		{
-
 			SEXP lst;
 			if (0 == current_row)
 			{
 				lst = PROTECT(allocVector(VECSXP, function->nargs));
 				for (i = 0; i < function->nargs; i++, t = CDR(t))
 				{
-					el = get_fn_expr_arg_stable(fcinfo->flinfo, i) ?
-						R_NilValue : pg_window_frame_get_r(winobj, i, function);
+					PROTECT(el = /* get_fn_expr_arg_stable(fcinfo->flinfo, i) ?
+						R_NilValue : */ pg_window_frame_get_r(winobj, i, function));
 					SET_VECTOR_ELT(lst, i, el);
+					UNPROTECT(1);
 					SETCAR(t, el);
 				}
 				defineVar(install(PLR_WINDOW_FRAME_NAME), lst, rho);
@@ -1787,15 +1785,15 @@ plr_convertargs(plr_function *function, Datum *arg, bool *argnull, FunctionCallI
 		else
 			for (i = 0; i < function->nargs; i++, t = CDR(t))
 			{
-				if (get_fn_expr_arg_stable(fcinfo->flinfo, i))
-					el = R_NilValue;
-				else
-				{
-					el = pg_window_frame_get_r(winobj, i, function);
-					numels = LENGTH(el);
-				}
+				PROTECT(el = /* get_fn_expr_arg_stable(fcinfo->flinfo, i) ?
+					R_NilValue : */ pg_window_frame_get_r(winobj, i, function));
+
 				SETCAR(t, el);
+				UNPROTECT(1);
 			}
+
+		/* below only works if last el <> R_NilValue (see commented out above) */
+		numels = function->nargs > 0 ? GET_LENGTH(el) : 0;
 
 		/* fnumrows */
 		SETCAR(t, ScalarInteger(numels));

--- a/plr.h
+++ b/plr.h
@@ -399,13 +399,13 @@ extern void R_RunExitFinalizers(void);
 		HeapTupleHeaderSetTypMod(dtrigtup, tupdesc->tdtypmod); \
 		SET_ARG(PointerGetDatum(dtrigtup),false,7); \
 	} while (0)
-#define CONVERT_TUPLE_TO_DATAFRAME \
+#define CONVERT_TUPLE_TO_DATAFRAME(tt) \
 	do { \
 		Oid			tupType; \
 		int32		tupTypmod; \
 		TupleDesc	tupdesc; \
 		HeapTuple	tuple = palloc(sizeof(HeapTupleData)); \
-		HeapTupleHeader	tuple_hdr = DatumGetHeapTupleHeader(GET_ARG_VALUE(i)); \
+		HeapTupleHeader	tuple_hdr = DatumGetHeapTupleHeader(tt); \
 		tupType = HeapTupleHeaderGetTypeId(tuple_hdr); \
 		tupTypmod = HeapTupleHeaderGetTypMod(tuple_hdr); \
 		tupdesc = lookup_rowtype_tupdesc(tupType, tupTypmod); \

--- a/sql/opt_window.sql
+++ b/sql/opt_window.sql
@@ -1,5 +1,5 @@
 create or replace function fast_win(a int4, b bigint) returns bool AS $$
-  is.null(farg2) || pg.throwerror('Constants shall not be passes with the frame')
+##is.null(farg2) || pg.throwerror('Constants shall not be passes with the frame')
   identical(parent.frame(), .GlobalEnv) && pg.throwerror('Parent env is global')
   exists('plr_window_frame', parent.frame(), inherits=FALSE) || pg.throwerror('No window frame data found')
   a == farg1[prownum]

--- a/sql/opt_window_frame.sql
+++ b/sql/opt_window_frame.sql
@@ -1,0 +1,10 @@
+create type tt as (x int, y int[]);
+create or replace function fast_win_frame(r int, t tt) returns bool AS $$
+  identical(parent.frame(), .GlobalEnv) && pg.throwerror('Parent env is global')
+  exists('plr_window_frame', parent.frame(), inherits=FALSE) || pg.throwerror('No window frame data found')
+  r == farg2[[prownum,2]][3]
+$$ window language plr;
+select s.r, s.p, fast_win_frame(NULLIF(r,4), (s.r, s.q)) over w
+from (select r, r % 2 as p, array_fill(case when r=7 then 77 else r end, ARRAY[3]) as q from  generate_series(1,10) r) s
+window w as (partition by p order by r rows between unbounded preceding and unbounded following)
+order by s.r;

--- a/sql/opt_window_frame.sql
+++ b/sql/opt_window_frame.sql
@@ -1,5 +1,4 @@
-create type tt as (x int, y int[]);
-create or replace function fast_win_frame(r int, t tt) returns bool AS $$
+create or replace function fast_win_frame(r int, t record) returns bool AS $$
   identical(parent.frame(), .GlobalEnv) && pg.throwerror('Parent env is global')
   exists('plr_window_frame', parent.frame(), inherits=FALSE) || pg.throwerror('No window frame data found')
   r == farg2[[prownum,2]][3]


### PR DESCRIPTION

This is based on 
a) the initial work by jconway which converted tuple arguments to PL/R non-window functions into one-row R dataframes (function pg_tuple_get_r_frame), and 
b) the very recent additions by mlt as model for the addition of pg_window_frame_get_r_frame() to return a multi-row R dataframe containing PG window frame custom type (tuple) data in fargX.

Please let me know your thoughts on this. Incidentally I have spotted what looks like a bug in plr_convertargs() where numels gets set close to the end. Moreover this constant value optimization is changing past intended behaviour: Would an on-the-fly N-times copy of the constant element into the fargX vector be a better solution maybe?
