### PR TITLE
fix hash_create, setting the hash function directly has been removed in 13, also fix some compiler warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,11 @@ os:
 language: c
 sudo : required 
 env:
+  - PG=12
   - PG=11
   - PG=10
   - PG=9.6
   - PG=9.5
-  - PG=9.4
 
 before_script:
   - sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,23 +13,21 @@ environment:
     PlatformToolset: v141
     configuration: Debug
     APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-  - pg: 9.4.22-1
+  - pg: 9.5.23-1
     PlatformToolset: v120
-  - pg: 9.5.17-1
+  - pg: 9.6.19-1
     PlatformToolset: v120
-  - pg: 9.6.13-1
+  - pg: 10.14-1
     PlatformToolset: v120
-  - pg: 10.8-1
-    PlatformToolset: v120
-  - pg: 11.3-1
+  - pg: 11.9-1
     PlatformToolset: v140
+  - pg: 12.4-1
+    PlatformToolset: v141
+  
 matrix:
   allow_failures:
     - pg: master
   exclude:
-    - platform: x86
-      pg: 11.3-1
-      PlatformToolset: v140
     - platform: x86
       pg: master
 

--- a/pg_backend_support.c
+++ b/pg_backend_support.c
@@ -117,7 +117,12 @@ plr_HashTableInit(void)
 	memset(&ctl, 0, sizeof(ctl));
 	ctl.keysize = sizeof(plr_func_hashkey);
 	ctl.entrysize = sizeof(plr_HashEnt);
+
+// specifying the hash function has been deprecated since 12
+#if (PG_VERSION_NUM >= 120000)
 	ctl.hash = tag_hash;
+#endif
+
 	plr_HashTable = hash_create("PLR function cache",
 								FUNCS_PER_USER,
 								&ctl,

--- a/pg_backend_support.c
+++ b/pg_backend_support.c
@@ -119,7 +119,7 @@ plr_HashTableInit(void)
 	ctl.entrysize = sizeof(plr_HashEnt);
 
 // specifying the hash function has been deprecated since 12
-#if (PG_VERSION_NUM >= 120000)
+#if (PG_VERSION_NUM <= 120000)
 	ctl.hash = tag_hash;
 #endif
 

--- a/pg_backend_support.c
+++ b/pg_backend_support.c
@@ -119,7 +119,7 @@ plr_HashTableInit(void)
 	ctl.entrysize = sizeof(plr_HashEnt);
 
 // specifying the hash function has been deprecated since 12
-#if (PG_VERSION_NUM <= 120000)
+#if (PG_VERSION_NUM < 120000)
 	ctl.hash = tag_hash;
 #endif
 

--- a/pg_backend_support.c
+++ b/pg_backend_support.c
@@ -121,12 +121,17 @@ plr_HashTableInit(void)
 // specifying the hash function has been deprecated since 12
 #if (PG_VERSION_NUM < 120000)
 	ctl.hash = tag_hash;
-#endif
 
 	plr_HashTable = hash_create("PLR function cache",
 								FUNCS_PER_USER,
 								&ctl,
 								HASH_ELEM | HASH_FUNCTION);
+#else
+	plr_HashTable = hash_create("PLR function cache",
+								FUNCS_PER_USER,
+								&ctl,
+								HASH_ELEM | HASH_BLOBS);
+#endif
 }
 
 plr_function *

--- a/plr.c
+++ b/plr.c
@@ -873,9 +873,9 @@ plr_func_handler(PG_FUNCTION_ARGS)
 	SEXP			rvalue;
 	Datum			retval;
 #ifdef HAVE_WINDOW_FUNCTIONS
-	WindowObject	winobj;
+	WindowObject	winobj = NULL;   	//set to NULL to silence compiler warnings
 	char			internal_env[PLR_WINDOW_ENV_NAME_MAX_LENGTH];
-	int64			current_row;
+	int64			current_row = -1;
 	int				check_err;
 #endif
 	ERRORCONTEXTCALLBACK;


### PR DESCRIPTION
Updated travis to use pg version 12