### PR TITLE
Support R sub-architectures

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 # location of R library
 
 ifdef R_HOME
-r_libdir1x = ${R_HOME}/bin
-r_libdir2x = ${R_HOME}/lib
+r_libdir1x = ${R_HOME}/bin${R_ARCH}
+r_libdir2x = ${R_HOME}/lib${R_ARCH}
 # location of R includes
 r_includespec = -I${R_HOME}/include
 rhomedef = ${R_HOME}


### PR DESCRIPTION
R for windows (non-cygwin), now always installs using sub-architectures.
Therefore, R is always installed in %R_HOME%/i386 or %R_HOME/x64.
A single architecture, chosen by the user, in the R installation,
will install into the sub-architecture.
This location is  Path/to/R/bin/i386 or Path/to/R/bin/x64.

To be able to use the Makefile to build
the PostgreSQL extension "plr", (using MSYS2),
the Makefile has to be enhanced, to handle R sub-architectures.

Changed inside Makefile, is the code from
```
r_libdir1x = ${R_HOME}/bin
r_libdir2x = ${R_HOME}/lib
```
to
```
r_libdir1x = ${R_HOME}/bin${R_ARCH}
r_libdir2x = ${R_HOME}/lib${R_ARCH}
```

Using MSYS2, the compilation (make & make install) instructions
of "R for windows (non-cygwin)" are (almost) the same.

https://github.com/postgres-plr/plr/blob/master/userguide.md#installation

The addition, is the setting of, one more environment variable, R_ARCH:
```
export R_ARCH=/i386
```
or
```
export R_ARCH=/x64
```
Rest of the "installation instructions" (make & make install)
follow as expected.

If "plr" is being compiled with a non-sub-architecture R,
then nothing must to be changed.
As expected, the environment variable R_ARCH is not set.
The environment variable R_ARCH does not exist, and R_ARCH is treated
as a zero length string inside the Makefile,
and the compilation is the same.

Fixes #80