### PR TITLE
Update for PostgreSQL >= 14

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -69,10 +69,10 @@ install:
       }
     }
 
-    on_finish:
+on_finish:
   - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
 
-  cache:
+cache:
 - '%exe%'
 - R-%rversion%-win.exe
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,6 +24,7 @@ matrix:
     - pg: master
 
 init: # Make %x64% available for caching
+- ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
 - if %PLATFORM%==x64 ( set pf=%ProgramFiles%&& set x64=-x64) else set pf=%ProgramFiles(x86)%
 - set exe=postgresql-%pg%-windows%x64%.exe
 - setx /m exe %exe%
@@ -68,7 +69,10 @@ install:
       }
     }
 
-cache:
+    on_finish:
+  - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
+
+  cache:
 - '%exe%'
 - R-%rversion%-win.exe
 
@@ -146,3 +150,4 @@ deploy:
       secure: sFXG3dBiC2S9bnHbDfg2fS0OdaxiSr6fGSlMQvQPb0lJGyKM3E5UZum4rik60zyi
    on:
       appveyor_repo_tag: true
+

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -69,8 +69,8 @@ install:
       }
     }
 
-on_finish:
-  - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
+#on_finish:
+# - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
 
 cache:
 - '%exe%'

--- a/msvc.diff
+++ b/msvc.diff
@@ -1,17 +1,18 @@
 diff --git a/src/tools/msvc/Mkvcbuild.pm b/src/tools/msvc/Mkvcbuild.pm
-index a083ac7..fcf44b7 100644
+index a184404e21..bedbd93ed2 100644
 --- a/src/tools/msvc/Mkvcbuild.pm
 +++ b/src/tools/msvc/Mkvcbuild.pm
-@@ -48,7 +48,7 @@ my @contrib_excludes = (
- 	'ltree_plpython',  'pgcrypto',
- 	'sepgsql',         'brin',
- 	'test_extensions', 'test_pg_dump',
--	'snapshot_too_old');
-+	'snapshot_too_old', 'plr');
+@@ -51,7 +51,8 @@ my @contrib_excludes = (
+	'pgcrypto',         'sepgsql',
+	'brin',             'test_extensions',
+	'test_misc',        'test_pg_dump',
+-	'snapshot_too_old', 'unsafe_tests');
++	'snapshot_too_old', 'unsafe_tests',
++	'plr');
  
  # Set of variables for frontend modules
  my $frontend_defines = { 'initdb' => 'FRONTEND' };
-@@ -463,6 +463,16 @@ sub mkvcbuild
+@@ -479,6 +480,16 @@ sub mkvcbuild
  	my $mf = Project::read_file('contrib/pgcrypto/Makefile');
  	GenerateContribSqlFiles('pgcrypto', $mf);
  
@@ -28,7 +29,7 @@ index a083ac7..fcf44b7 100644
  	foreach my $subdir ('contrib', 'src/test/modules')
  	{
  		opendir($D, $subdir) || croak "Could not opendir on $subdir!\n";
-@@ -1011,6 +1021,15 @@ sub GenerateContribSqlFiles
+@@ -1035,6 +1046,15 @@ sub GenerateContribSqlFiles
  			}
  		}
  	}
@@ -45,10 +46,10 @@ index a083ac7..fcf44b7 100644
  }
  
 diff --git a/src/tools/msvc/vcregress.pl b/src/tools/msvc/vcregress.pl
-index ce5c976..9d3e119 100644
+index d9bac6c3a2..25501eeb2d 100644
 --- a/src/tools/msvc/vcregress.pl
 +++ b/src/tools/msvc/vcregress.pl
-@@ -429,7 +429,7 @@ sub contribcheck
+@@ -467,7 +467,7 @@ sub contribcheck
  {
  	chdir "../../../contrib";
  	my $mstat = 0;

--- a/pg_backend_support.c
+++ b/pg_backend_support.c
@@ -225,11 +225,16 @@ get_lib_pathstr(Oid langOid)
 		char   *result;
 		int		bc;
 		size_t	len = strlen(raw_path);
-
 		bc = (len - 2)/2 + 1;            /* maximum possible length */
+
+#if PG_VERSION_NUM >= 140000
+		result = palloc0(bc);
+		bc = pg_hex_decode(raw_path + 2, len - 2, result, bc);
+#else
 		result = palloc0(bc);
 
 		bc = hex_decode(raw_path + 2, len - 2, result);
+#endif
 		cooked_path = expand_dynamic_library_name(result);
 	}
 	else

--- a/plr.h
+++ b/plr.h
@@ -133,7 +133,11 @@ extern int R_SignalHandlers;
 #endif
 
 #define WARNING		19
+#if PG_VERSION_NUM >= 140000 
+#define ERROR		21
+#else
 #define ERROR		20
+#endif
 
 /* starting in R-2.7.0 this defn was removed from Rdevices.h */
 #ifndef KillAllDevices

--- a/plr.h
+++ b/plr.h
@@ -132,9 +132,14 @@ extern int R_SignalHandlers;
 #undef WARNING
 #endif
 
+#ifdef PGWARNING
+#define WARNING		PGWARNING
+#else
 #define WARNING		19
-#if PG_VERSION_NUM >= 140000 
-#define ERROR		21
+#endif
+
+#ifdef PGERROR
+#define ERROR		PGERROR
 #else
 #define ERROR		20
 #endif

--- a/plr.h
+++ b/plr.h
@@ -63,7 +63,12 @@
 #include "storage/ipc.h"
 #include "tcop/tcopprot.h"
 #include "utils/array.h"
+
+#if PG_VERSION_NUM >= 140000
+#include "common/hex.h"
+#endif
 #include "utils/builtins.h"
+
 #if PG_VERSION_NUM >= 80500
 #include "utils/bytea.h"
 #endif


### PR DESCRIPTION
update msvc.diff to account for changes
hex_decode has been removed in 14 in favour of pg_hex_decode, adjust code to call new function for versions greater than or equal to 14.0