### PR TITLE
Issue 96 - Non-MSVC Installs Should Have the plr--8.3.0.18--8.4.sql Converter File

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ PG_CPPFLAGS	+= $(r_includespec)
 SRCS		+= plr.c pg_conversion.c pg_backend_support.c pg_userfuncs.c pg_rsupport.c
 OBJS		:= $(SRCS:.c=.o)
 SHLIB_LINK	+= -L$(r_libdir1x) -L$(r_libdir2x) -lR
-DATA		= plr--8.4.1.sql plr--8.4--8.4.1.sql plr--unpackaged--8.4.1.sql
+DATA		= plr--8.4.1.sql plr--8.4--8.4.1.sql plr--unpackaged--8.4.1.sql plr--8.3.0.18--8.4.sql
 REGRESS		= plr bad_fun opt_window do out_args
 
 ifdef USE_PGXS


### PR DESCRIPTION

In the Makefile .
https://github.com/postgres-plr/plr/blob/98eb0cd0846aea3732c28fcb24129b8275ad61d9/Makefile#L25

The version converter file, .sql file number four(4), is missing.
```
plr--8.3.0.18--8.4.sql
```

The case seems `proper`, to have all the .sql files.
E.g., cube" has all of the .sql files including all of the converters
(spread over two lines).

https://github.com/postgres/postgres/blob/112d411fbeb56afd18c117e20b524a86afc9aba5/contrib/cube/Makefile#L10
https://github.com/postgres/postgres/blob/112d411fbeb56afd18c117e20b524a86afc9aba5/contrib/cube/Makefile#L11
```
DATA = cube--1.2.sql cube--1.2--1.3.sql cube--1.3--1.4.sql cube--1.4--1.5.sql \
	cube--1.1--1.2.sql cube--1.0--1.1.sql
```

Fixes #96