### PR TITLE
Issue #100 Pull #49 Implement PostgreSQL 11 Transaction Management

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ SRCS		+= plr.c pg_conversion.c pg_backend_support.c pg_userfuncs.c pg_rsupport.c
 OBJS		:= $(SRCS:.c=.o)
 SHLIB_LINK	+= -L$(r_libdir1x) -L$(r_libdir2x) -lR
 DATA		= plr--8.4.1.sql plr--8.4--8.4.1.sql plr--unpackaged--8.4.1.sql plr--8.3.0.18--8.4.sql
-REGRESS		= plr bad_fun opt_window do out_args
+REGRESS		= plr bad_fun opt_window do out_args plr_transaction
 
 ifdef USE_PGXS
 ifndef PG_CONFIG

--- a/expected/plr_transaction.out
+++ b/expected/plr_transaction.out
@@ -1,0 +1,57 @@
+CREATE TABLE test1 (a int, b text);
+CREATE OR REPLACE FUNCTION test_create_procedure_transaction() RETURNS void
+  AS
+$BODY$
+  version_11plus  <- pg.spi.exec("SELECT current_setting('server_version_num')::integer >= 110000;")
+  if(version_11plus[[1]])
+  {
+    pg.spi.exec("
+      CREATE OR REPLACE PROCEDURE transaction_test1()
+        AS
+      $$
+        for(i in 0:9){
+          pg.spi.exec(paste('INSERT INTO test1 (a) VALUES (', i, ');'))
+          if (i %% 2 == 0) {
+            pg.spi.commit()
+          } else {
+            pg.spi.rollback()
+          }
+        }
+      $$ LANGUAGE plr;
+      ")
+  }
+  else
+  {
+    pg.spi.exec("INSERT INTO test1 (a) VALUES (0);")
+    pg.spi.exec("INSERT INTO test1 (a) VALUES (2);")
+    pg.spi.exec("INSERT INTO test1 (a) VALUES (4);")
+    pg.spi.exec("INSERT INTO test1 (a) VALUES (6);")
+    pg.spi.exec("INSERT INTO test1 (a) VALUES (8);")
+  }
+$BODY$
+LANGUAGE plr;
+SELECT test_create_procedure_transaction();
+ test_create_procedure_transaction 
+-----------------------------------
+ 
+(1 row)
+
+\o out.txt
+SELECT current_setting('server_version_num')::integer server_version_num;
+\o
+\gset
+\o out.txt
+SELECT CASE WHEN :server_version_num >= 110000 THEN 'CALL transaction_test1();' ELSE '' END thecall;
+\o
+\gset
+:thecall
+SELECT * FROM test1;
+ a | b 
+---+---
+ 0 | 
+ 2 | 
+ 4 | 
+ 6 | 
+ 8 | 
+(5 rows)
+

--- a/pg_rsupport.c
+++ b/pg_rsupport.c
@@ -830,3 +830,29 @@ rsupport_error_callback(void *arg)
 		errcontext("In R support function %s", (char *) arg);
 }
 
+#if PG_VERSION_NUM >= 110000
+/*
+ * plr_SPI_commit - commit transaction and start a new one.
+ */
+SEXP
+plr_SPI_commit(void)
+{
+	SPI_commit();
+	SPI_start_transaction();
+
+	return NULL;
+}
+
+/*
+ * plr_SPI_rollback - abort transaction and start a new one.
+ */
+SEXP
+plr_SPI_rollback(void)
+{
+	SPI_rollback();
+	SPI_start_transaction();
+
+	return NULL;
+}
+#endif
+

--- a/plr.h
+++ b/plr.h
@@ -553,6 +553,10 @@ PGDLLEXPORT void plr_SPI_cursor_close(SEXP cursor_in);
 PGDLLEXPORT void plr_SPI_cursor_move(SEXP cursor_in, SEXP forward_in, SEXP rows_in);
 PGDLLEXPORT SEXP plr_SPI_lastoid(void);
 PGDLLEXPORT void throw_r_error(const char **msg);
+#if PG_VERSION_NUM >= 110000
+PGDLLEXPORT SEXP plr_SPI_commit(void);
+PGDLLEXPORT SEXP plr_SPI_rollback(void);
+#endif
 
 /* Postgres callable functions useful in conjunction with PL/R */
 PGDLLEXPORT Datum plr_version(PG_FUNCTION_ARGS);

--- a/sql/plr_transaction.sql
+++ b/sql/plr_transaction.sql
@@ -1,0 +1,49 @@
+CREATE TABLE test1 (a int, b text);
+
+CREATE OR REPLACE FUNCTION test_create_procedure_transaction() RETURNS void
+  AS
+$BODY$
+  version_11plus  <- pg.spi.exec("SELECT current_setting('server_version_num')::integer >= 110000;")
+  if(version_11plus[[1]])
+  {
+    pg.spi.exec("
+      CREATE OR REPLACE PROCEDURE transaction_test1()
+        AS
+      $$
+        for(i in 0:9){
+          pg.spi.exec(paste('INSERT INTO test1 (a) VALUES (', i, ');'))
+          if (i %% 2 == 0) {
+            pg.spi.commit()
+          } else {
+            pg.spi.rollback()
+          }
+        }
+      $$ LANGUAGE plr;
+      ")
+  }
+  else
+  {
+    pg.spi.exec("INSERT INTO test1 (a) VALUES (0);")
+    pg.spi.exec("INSERT INTO test1 (a) VALUES (2);")
+    pg.spi.exec("INSERT INTO test1 (a) VALUES (4);")
+    pg.spi.exec("INSERT INTO test1 (a) VALUES (6);")
+    pg.spi.exec("INSERT INTO test1 (a) VALUES (8);")
+  }
+$BODY$
+LANGUAGE plr;
+
+SELECT test_create_procedure_transaction();
+
+\o out.txt
+SELECT current_setting('server_version_num')::integer server_version_num;
+\o
+\gset
+
+\o out.txt
+SELECT CASE WHEN :server_version_num >= 110000 THEN 'CALL transaction_test1();' ELSE '' END thecall;
+\o
+\gset
+
+:thecall
+
+SELECT * FROM test1;


### PR DESCRIPTION
PostgreSQL languages PL/pgSQL, PL/Perl, and PL/perl can perform Transaction Management (since pg 11). https://www.postgresql.org/docs/11/plpgsql-transactions.html

Transaction Management (within those PL languages) was implemented in this commit.
https://github.com/postgres/postgres/commit/8561e4840c81f7e345be2df170839846814fa004

PL/R deserves to be able to also do this.

This pull request is almost a continuation (or duplicate) of this pull request.

add support for procedures from Peter Eisentraut #49
https://github.com/postgres-plr/plr/pull/49

My pull request adds 

```
(1) pg version "C code" conditional compilation 
     (because required "PostgreSQL procedures" started existing in pg 11 and onward.)

(2) regression check (that works-around procedures not existing before pg 11).

(3) implemented from the current git HEAD of the postgres-plr master branch (so no conficts).
```
Transaction Management was implemented in a Peter Eisentraut "personal" PL/R (but never finished being implemented in "postgres-plr" PL/R)

Transaction control in PL procedures
https://github.com/petere/plr/commit/1b275d1337f724e0330ecc027186a052509260fa 


An extra test is here using pg "master" (3 days old) and upon the beta version of R (4.1.0beta) of the next major version of R: 4.1 (that is scheduled for release before the end of this month).
https://ci.appveyor.com/project/AndreMikulec/plr/builds/39008938/job/7tlolbs4qivhxdry#L695

Fixes #100
Fixes https://github.com/postgres-plr/plr/pull/49

