### PR TITLE
Issue Fix #89 Appveyor: patching of Mkvcbuild.pm and vcregress.pl, should happen automatically

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,14 +5,23 @@ clone_depth: 1
 environment:
   PGUSER: postgres
   PGPASSWORD: Password12!
-  rversion: 3.6.0
+  rversion: 4.1.0
   matrix:
+
   - pg: master
     PlatformToolset: v141
     configuration: Debug
-#try version 4
-    rversion: 4.1.0
     APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+
+  - pg: REL_13_0
+    PlatformToolset: v141
+    configuration: Release
+    APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+  - pg: REL_12_0
+    PlatformToolset: v141
+    configuration: Release
+    APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+
   - pg: 9.6.13-1
     PlatformToolset: v120
   - pg: 11.11-2
@@ -23,7 +32,7 @@ environment:
   - pg: 13.2-2
     PlatformToolset: v141
     APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-  
+
 matrix:
   allow_failures:
     - pg: master
@@ -41,23 +50,47 @@ install:
 #- if not exist Rtools35.exe appveyor downloadfile https://cran.r-project.org/bin/windows/Rtools/Rtools35.exe
 #- Rtools35.exe /VERYSILENT
 - Set mingw=C:\msys64\mingw
-# http://www.databasesoup.com/2016/05/changing-postgresql-version-numbering.html
-- for /f "tokens=1 delims=-" %%A in ("%pg%") do set pgversion=%%~nA
+#
+# From the EnterpriseDB version name,
+# if any, strip off the: right-most part dot, then numbers, then one hyphen, then numbers.
+- ps: $env:pgversion = $env:pg -replace "[.]\d+-\d+$", ""
+#
 - echo pgversion=%pgversion%
 - set pgroot=%pf%\PostgreSQL\%pgversion%
 - echo %pgroot%
 - SET R_HOME=%ProgramFiles%\R\R-%rversion%
 - set RBIN=%PLATFORM:x86=i386%
 - SET sed=C:\msys64\usr\bin\sed
+# R in the path is not required: msvc compilation
+# R in the path is required: find Rscript
+- set PATH=%R_HOME%\bin\%rbin%;%PATH%
+# environment variable "postgresrcroot" is required for msvc.diff.R
+- set postgresrcroot=C:\projects\postgresql
 - ps: |
-    if ("$env:pg" -eq "master") {
+    # notmatch - if no "dot is found" in pg name, then pg is a: git: branch, tag, or commit.
+    if ("${env:pg}" -notmatch "[.]") {
       $env:Path += ";C:\msys64\usr\bin;C:\msys64\mingw64\bin;C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\bin\amd64"
-      git clone -q --depth 1 https://git.postgresql.org/git/postgresql.git c:\projects\postgresql
+      git config --global advice.detachedHead false
+      #
+      # git commit
+      #
+      if(("${env:pg}" -cmatch  "^[a-z0-9]+$") -and ("${env:pghint}" -eq "commit")) {
+        git clone -q  https://git.postgresql.org/git/postgresql.git  c:\projects\postgresql
+        pushd c:\projects\postgresql
+        git checkout -q  ${env:pg} -b ${env:pg}
+        popd
+      #
+      # git branch or tag(detached head)
+      # PostgreSQL case - git branches and tags have at least one capital letter - but expect mostly CAPS
+      #
+      } else {
+        git clone -q --depth 1 --branch ${env:pg} https://git.postgresql.org/git/postgresql.git  c:\projects\postgresql
+      }
       gendef - "$env:R_HOME\bin\$env:rbin\R.dll" > "R$env:PLATFORM.def" 2> $null
       lib "/def:R$env:PLATFORM.def" "/out:R$env:PLATFORM.lib" "/MACHINE:$env:PLATFORM"
       pushd c:\projects\postgresql
       cmd /c mklink /J contrib\plr $env:APPVEYOR_BUILD_FOLDER
-      patch -p1 -i "$env:APPVEYOR_BUILD_FOLDER\msvc.diff"
+      Rscript --vanilla "${env:APPVEYOR_BUILD_FOLDER}\msvc.diff.R"
       perl contrib\plr\buildsetup.pl
       popd
       $env:PROJ="C:\projects\postgresql\pgsql.sln"
@@ -99,7 +132,7 @@ after_build:
 - set zip=plr-%APPVEYOR_REPO_COMMIT:~0,8%-pg%pgversion%-R%rversion%-%PLATFORM%-%CONFIGURATION%.zip
 - 7z a -r %zip% .\tmp\* > nul
 - ps: |
-    if ("$env:pg" -eq "master") {
+    if ("$env:pg" -notmatch "[.]") {
       pushd c:\projects\postgresql\src\tools\msvc
       perl install.pl "$env:pgroot"
       popd
@@ -108,7 +141,7 @@ after_build:
 test_script:
 - path %pgroot%\bin;%PATH%
 - ps: |
-    if ("$env:pg" -eq "master") {
+    if ("$env:pg" -notmatch "[.]") {
       Set-Content -path pg.pass -value "$env:pgpassword" -encoding ascii
       initdb -A md5 -U "$env:PGUSER" --pwfile=pg.pass C:\pgdata
       pg_ctl register -S demand -N "postgresql$env:x64-$env:pgversion" -D c:\pgdata
@@ -117,7 +150,7 @@ test_script:
       7z x "$env:zip" "-o$env:pgroot"
     }
 - appveyor AddMessage "Starting the database server." -Category Information
-- setx /M PATH "%R_HOME%\bin\%RBIN%;%PATH%"
+- setx /M PATH "%R_HOME%\bin\%rbin%;%PATH%"
 - net start postgresql%x64%-%pgversion%
 
 - ps: |
@@ -130,7 +163,7 @@ test_script:
     $env:Outcome="Passed"
     $elapsed=(Measure-Command {
       pg_regress "$env:psqlopt=$env:pgroot\bin" --dbname=pl_regression plr `
-        bad_fun opt_window do out_args 2>&1 |
+        bad_fun opt_window do out_args plr_transaction 2>&1 |
         %{ if ($_ -is [System.Management.Automation.ErrorRecord]) { $_.Exception.Message } else { $_ } } |
           Out-Default
       if ($LASTEXITCODE -ne 0) {

--- a/msvc.diff.R
+++ b/msvc.diff.R
@@ -1,0 +1,186 @@
+
+# derived from msvc.diff (PostgreSQL Release 13.2)
+
+###############################################################################################
+# This R script dynamically edits Mkvcbuild.pm and vcregress.pl
+###############################################################################################
+
+# Required: get the environment variable - postgresrcroot
+#
+# e.g. set postgresrcroot=C:\projects\postgresql
+#
+postgresrcroot <- Sys.getenv("postgresrcroot")
+postgresrcroot <- normalizePath(postgresrcroot, winslash="/", mustWork = T)
+
+
+MkvcbuildPathFile <- paste0(postgresrcroot, "/src/tools/msvc/Mkvcbuild.pm")
+Mkvcbuild.pm.Lines <- readLines(MkvcbuildPathFile)
+
+insContribExcludesArray <- function(lines) {
+
+  # lines
+  LineOnlyBeginPos <- which(grepl("@contrib_excludes\\s+=\\s+\\(", x = lines, perl = TRUE))
+  LineAllHaveRightParensPos <- which(grepl("\\)", x = lines, perl = TRUE))
+  # after BeginPos, first-found line that has a right paren
+  LineOnlyEndPos <- LineAllHaveRightParensPos[head(which(LineOnlyBeginPos <= LineAllHaveRightParensPos),1)]
+
+  ModifyLineWorking <- lines[LineOnlyEndPos]
+
+  # within that line
+  # find the right-most paren
+  LastParenPos <- tail(gregexpr("\\)", text = ModifyLineWorking, perl = TRUE)[[1L]],1L)
+  # insert into that line
+  ModifyLineWorking <- paste0(append(strsplit(ModifyLineWorking, split = "")[[1L]], ", 'plr'", after = LastParenPos - 1L), collapse = "")
+
+  lines[LineOnlyEndPos] <- ModifyLineWorking
+
+  writeLines("")
+  writeLines("BEGIN insContribExcludesArray ")
+  writeLines("")
+  writeLines(lines[LineOnlyBeginPos:LineOnlyEndPos])
+  writeLines("")
+  writeLines("END   insContribExcludesArray ")
+  writeLines("")
+
+  return(lines)
+
+}
+
+# 1 - add 'plr' to @contrib_excludes array
+Mkvcbuild.pm.Lines <- insContribExcludesArray(Mkvcbuild.pm.Lines)
+
+
+
+addProjectCode  <- function(lines) {
+
+  LineOnlyBeginPos    <- which(grepl("sub\\s+mkvcbuild", x = lines, perl = TRUE))
+  LineLastPgCryptoPos <- which(grepl("GenerateContribSqlFiles\\s*\\(\\s*'pgcrypto'", x = lines , perl = TRUE))
+  # after BeginPos, first-found line
+  LineOnlyPos <- LineLastPgCryptoPos[head(which(LineOnlyBeginPos < LineLastPgCryptoPos),1)]
+
+  plrProjectText <-
+"\tmy $plr = $solution->AddProject('plr','dll','plr','contrib/plr');
+\t$plr->AddFiles(
+\t\t'contrib\\plr','plr.c','pg_conversion.c','pg_backend_support.c','pg_userfuncs.c','pg_rsupport.c'
+\t);
+\t$plr->AddReference($postgres);
+\t$plr->AddLibrary('contrib/plr/R$(PlatformTarget).lib');
+\t$plr->AddIncludeDir('$(R_HOME)\\include');
+\tmy $mfplr = Project::read_file('contrib/plr/Makefile');
+\tGenerateContribSqlFiles('plr', $mfplr);
+
+"
+  # insert into the file
+  lines <- append(lines, strsplit(plrProjectText, split = "\n")[[1L]], after =  LineOnlyPos + 1L)
+
+  writeLines("")
+  writeLines("BEGIN AddProjectCode")
+  writeLines("")
+  writeLines(lines[LineOnlyPos:(LineOnlyPos + 10L)])
+  writeLines("")
+  writeLines("END   AddProjectCode")
+  writeLines("")
+
+  return(lines)
+
+}
+
+# 2 - part of "sub mkvcbuild" - add 'plr' project
+Mkvcbuild.pm.Lines <- addProjectCode(Mkvcbuild.pm.Lines)
+
+
+
+addGenerateContribSqlFilesCode <- function(lines) {
+
+  # lines
+  LineOnlyBeginPos   <- which(grepl("sub\\s+GenerateContribSqlFiles", x = lines, perl = TRUE))
+
+  # pg 11 and later has "return;"
+  LineAllHaveReturnsPos <- which(grepl("\\breturn\\s*;", x = lines, perl = TRUE))
+  if(length(LineAllHaveReturnsPos)) {
+    # after BeginPos, first-found line
+    LineOfContribReturnPos <- LineAllHaveReturnsPos[head(which(LineOnlyBeginPos < LineAllHaveReturnsPos),1L)]
+  } else {
+    # earlier than pg 11
+    # just find the function closing end-left-facing-brace
+    LineAllHaveReturnsPos <- which(grepl("^}$", x = lines, perl = TRUE))
+    LineOfContribReturnPos <- LineAllHaveReturnsPos[head(which(LineOnlyBeginPos < LineAllHaveReturnsPos),1L)]
+  }
+  plrGenerateContribSqlFilesText <-
+"\telse
+\t{
+\t\tprint \"GenerateContribSqlFiles skipping $n\\n\";
+\t\tif ($n eq 'plr')
+\t\t{
+\t\t\tprint \"mf: $mf\\n\";
+\t\t}
+\t}
+"
+  # insert into the file to the position "just above", the "return" statement, xor, "function closing function closing end-left-facing-brace"
+  lines <- append(lines, strsplit(plrGenerateContribSqlFilesText, split = "\n")[[1L]], after =  LineOfContribReturnPos -1L)
+
+  writeLines("")
+  writeLines("BEGIN addGenerateContribSqlFilesCode")
+  writeLines("")
+  writeLines(lines[LineOnlyBeginPos:(LineOfContribReturnPos + 7L + 1L + 1L)])
+  writeLines("")
+  writeLines("END   addGenerateContribSqlFilesCode")
+  writeLines("")
+
+  return(lines)
+
+}
+
+# 3 - part of "sub GenerateContribSqlFiles" - add - else 'plr'
+Mkvcbuild.pm.Lines <- addGenerateContribSqlFilesCode(Mkvcbuild.pm.Lines)
+
+
+
+cat(file = MkvcbuildPathFile, Mkvcbuild.pm.Lines, sep = "\n")
+
+
+vcregressPathFile <- paste0(postgresrcroot, "/src/tools/msvc/vcregress.pl")
+vcregress.pl.Lines <- readLines(vcregressPathFile)
+
+modifySubContribCheck <- function(lines) {
+
+  # lines
+  LineOnlyBeginPos   <- which(grepl("sub\\s+contribcheck", x = lines, perl = TRUE))
+  LineAllHaveGlobPos <- which(grepl("foreach\\s+my\\s+[$]module\\s+\\(glob\\(", x = lines, perl = TRUE))
+  # after BeginPos, first-found line
+  LineOfGlobPos <- LineAllHaveGlobPos[head(which(LineOnlyBeginPos < LineAllHaveGlobPos),1L)]
+
+  ModifyLineWorking <- lines[LineOfGlobPos]
+
+  # within that line
+  LastAsteriskPos <- tail(gregexpr("[*]", text = ModifyLineWorking, perl = TRUE)[[1L]],1L)
+
+  ModifyLineWorking <- strsplit(ModifyLineWorking, split = "")[[1L]]
+  # remove that asterisk
+  ModifyLineWorking <- as.list(ModifyLineWorking)
+  ModifyLineWorking[LastAsteriskPos] <- NULL
+  ModifyLineWorking <- unlist(ModifyLineWorking)
+  ModifyLineWorking <- paste0(ModifyLineWorking, collapse = "")
+
+  # insert into the line at the old-asterisk position
+  ModifyLineWorking <- paste0(append(strsplit(ModifyLineWorking, split = "")[[1L]], "plr", after = LastAsteriskPos - 1L), collapse = "")
+  lines[LineOfGlobPos] <- ModifyLineWorking
+
+  writeLines("")
+  writeLines("BEGIN modifySubContribCheck ")
+  writeLines("")
+  writeLines(lines[LineOnlyBeginPos:LineOfGlobPos])
+  writeLines("")
+  writeLines("END   modifySubContribCheck ")
+  writeLines("")
+
+  return(lines)
+
+}
+
+# 4 - part of sub contribcheck - reduce concern to only 'plr'
+vcregress.pl.Lines <- modifySubContribCheck(vcregress.pl.Lines)
+
+
+cat(file = vcregressPathFile, vcregress.pl.Lines, sep = "\n")
+


### PR DESCRIPTION
Currently, the msvc.diff file works on PostgreSQL 13 and master.

One is limited, in such a way, that one can not use msvc and the msvc.diff to
compile from source, PostgreSQL 12 (that is currently, still supported).
So, if someone should ask for a msvc "plr that is compiled from PostgreSQL 12 source",
one can not build that plr.

msvc.diff is used to modify the file Mkvcbuild.pm and vcregress.pl.
This file, Mkvcbuild.pm, is under heavy maintenance, and is modified using
the frequency, of once or twice per month.

https://github.com/postgres/postgres/commits/master/src/tools/msvc/Mkvcbuild.pm

In the master branch, in Mkvcbuild.pm (or vcregress.pl),
the situation is that every time someone (1) vertically shifts a line
or (2) or modifies of the Perl array @contrib_excludes,
one has to create a new msvc.diff file.

This fix enhances:

  1. avoids the manual re-creation of the msvc.diff file
     that would occur in Mkvcbuild.pm (and vcregress.pl) after
     (1) a vertical line shift or
     (2) addition or modification of the Perl array @contrib_excludes.
     by
     including a file msvc.diff.R that is a program that
     modifies the Mkvcbuild.pm and vcregress.pl.

  2. adds the ability to compile plr using PostgreSQL
     git branches, git tags, or git commit hashes

  3. adds demo compilations plr using PostgreSQL
     versions(git tags): REL_13_0 and REL_12_0

Issue Fix https://github.com/postgres-plr/plr/issues/89