### PR TITLE
Update versions of PG and R. Introduce the meson build system.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,6 @@
 name: plr CI
+run-name: plr CI - ${{ github.event.head_commit.message }}
+
 on: [push, pull_request]
 jobs:
   master:
@@ -48,7 +50,6 @@ jobs:
       PG: ${{ matrix.pg }}
     strategy:
       matrix:
-        pg: [15, 14, 13, 12, 11, 10]
         include:
           - pg: 15
           - pg: 14

--- a/.github/workflows/buildPLR.yml
+++ b/.github/workflows/buildPLR.yml
@@ -1,0 +1,2395 @@
+name: Meson Builds PL/R
+run-name: Meson Builds PL/R - ${{ github.event.head_commit.message }}
+on: [push, pull_request, workflow_dispatch]
+jobs:
+  build_test_install:
+    name: R ${{ matrix.rversion }} PGsrc ${{ matrix.pgSRCversion }} PGbin ${{ matrix.pgWINversion }} ${{ matrix.compilerEnv }} ${{ matrix.Platform }}  ${{ matrix.os }} ${{ matrix.Configuration }}
+    runs-on: ${{ matrix.os }}
+    # With "continue-on-error" (and with "fail-fast") emulate Appveyor "allow_failures"
+    # Prevents a workflow run from failing when a job fails. Set to true to allow a workflow run to pass when this job fails.
+    # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idcontinue-on-error
+    continue-on-error: ${{ matrix.GithubActionsIgnoreFail }}
+    strategy:
+      # Disable fail-fast as we want results from all even if one fails.
+      fail-fast: false
+      matrix:
+        include:
+
+          # Note, the x86 Cygwin Server will "not start" on Github Actions
+          # Therfore cygwin x86 is "not PostgreSQL regression testable."
+          #
+          # Repository R and Repository Postgresql
+          # Package: R
+          # https://www.cygwin.com/packages/summary/R.html
+          # Package: postgresql
+          # https://www.cygwin.com/packages/summary/postgresql.html
+          #
+          - os: windows-latest
+            GithubActionsIgnoreFail: false
+            compilerEnv: cygwin
+            Platform: x64
+            Configuration: Release
+
+          # plr for "R 4.3.0 (and later) for Windows" can not be compiled with Microsoft Visual Studio.
+          # Therefore, here, plr for "R 4.3.0 (and later) for Windows" is compiled with MSYS2(UCRT64/MINGW32).
+          # It is regression tested twice.  The first regression test is within PostgreSQL on MSYS2.
+          # The second regression test is within PostgreSQL on Windows.
+          #
+          # Here are the reasons why plr for "R 4.3.0 (and later) for Windows" can not be compiled with Microsoft Visual Studio.
+          #
+          # Bug 18544 - private_data_c Visual Studio 2022 R-4.3.0 Complex.h(81,21): syntax error: missing ';' before identifier 'private_data_c'
+          # Status: CLOSED WONTFIX
+          # https://bugs.r-project.org/show_bug.cgi?id=18544
+          #
+          # The new definition does not work with MSVC compilers because they don't support the C99 _Complex type
+          # https://learn.microsoft.com/en-us/cpp/c-runtime-library/complex-math-support?view=msvc-170
+          #
+          # C Complex Numbers in C++?
+          # https://stackoverflow.com/questions/10540228/c-complex-numbers-in-c
+          #
+          # bleeding edge R and bleeding edge PostgreSQL
+          - os: windows-latest
+            GithubActionsIgnoreFail: true
+            compilerEnv: UCRT64
+            shellEnv: msys2 {0}
+            compilerExe: gcc
+            Platform: x64
+            Configuration: Debug
+            #
+            rversion:  devel
+            R_HOME: 'D:\RINSTALL'
+            R_ARCH: /x64
+            #
+            pgSRCversion: master
+            PG_SOURCE: 'D:\PGSOURCE'
+            buildpgFromSRC: true
+            buildpgFromSRCmethod: meson
+            PG_HOME: 'D:\PGINSTALL'
+            #
+            # pgWINversion: master.future-future
+            #
+            # not "MSYS2testonpgWIN: true" - because no existing "PostgreSQL master for Windows" exists anywhere.
+
+          # bleeding edge R and next PostgreSQL
+          - os: windows-latest
+            GithubActionsIgnoreFail: false
+            compilerEnv: UCRT64
+            shellEnv: msys2 {0}
+            compilerExe: gcc
+            Platform: x64
+            Configuration: Debug
+            #
+            rversion:  devel
+            R_HOME: 'D:\RINSTALL'
+            R_ARCH: /x64
+            #
+            pgSRCversion: REL_16_0
+            PG_SOURCE: 'D:\PGSOURCE'
+            #
+            # buildpgFromSRC: true
+            # buildpgFromSRCmethod: make/meson(PostgreSQL 16+)
+            #   Add meson build system (Andres Freund, Nazir Bilal Yavuz, Peter Eisentraut)
+            #   https://www.postgresql.org/docs/16/release-16.html
+            # xor
+            buildpgANDplrInSRCcontrib: true
+            PG_HOME: 'D:\PGINSTALL'
+            #
+            pgWINversion: 16.0-1
+            # 
+            MSYS2testonpgWIN: true
+
+          - os: windows-latest
+            GithubActionsIgnoreFail: false
+            compilerEnv: UCRT64
+            shellEnv: msys2 {0}
+            compilerExe: gcc
+            Platform: x64
+            Configuration: Release
+            #
+            rversion: 4.3.1
+            R_HOME: 'D:\RINSTALL'
+            R_ARCH: /x64
+            #
+            # September 2023 - MSYS2 PostgreSQL version is 15.3
+            #
+            # See the UCRT repository postgreSQL version
+            # https://packages.msys2.org/package/mingw-w64-ucrt-x86_64-postgresql
+            #
+            # pgSRCversion: REL_15
+            # PG_SOURCE: 'D:\PGSOURCE'
+            # buildpgFromSRC: true
+            # buildpgFromSRCmethod: make
+            # PG_HOME: 'D:\PGINSTALL'
+            #
+            # download from EnterpriseDB - PostgreSQL for Windows
+            pgWINversion: 15.3-3
+            #
+            MSYS2testonpgWIN: true
+
+          - os: windows-latest
+            GithubActionsIgnoreFail: false
+            compilerEnv: UCRT64
+            shellEnv: msys2 {0}
+            compilerExe: gcc
+            Platform: x64
+            Configuration: Release
+            #
+            rversion: 4.3.1
+            R_HOME: 'D:\RINSTALL'
+            R_ARCH: /x64
+            #
+            pgSRCversion: REL_14_8
+            PG_SOURCE: 'D:\PGSOURCE'
+            buildpgFromSRC: true
+            buildpgFromSRCmethod: make
+            PG_HOME: 'D:\PGINSTALL'
+            #
+            # EnterpriseDB PostgreSQL for Windows
+            # pgWINversion: 14.x-y
+            #
+            # September 2023 - Pre-installed Github Actions PostgreSQL for Windows version is x64-14
+            # ServiceName postgresql-x64-14
+            # Version 14.8
+            # https://github.com/actions/runner-images/blob/main/images/win/Windows2022-Readme.md
+            # https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-software
+            #
+            MSYS2testonpgWIN: true
+
+          - os: windows-latest
+            GithubActionsIgnoreFail: false
+            compilerEnv: UCRT64
+            shellEnv: msys2 {0}
+            compilerExe: gcc
+            Platform: x64
+            Configuration: Release
+            #
+            rversion: 4.3.1
+            R_HOME: 'D:\RINSTALL'
+            R_ARCH: /x64
+            #
+            pgSRCversion: REL_13_12
+            PG_SOURCE: 'D:\PGSOURCE'
+            buildpgFromSRC: true
+            buildpgFromSRCmethod: make
+            PG_HOME: 'D:\PGINSTALL'
+            #
+            pgWINversion: 13.12-1
+            #
+            MSYS2testonpgWIN: true
+
+          # PG 12 x64 and PG 11 x64
+          # R 4.3.1 PGsrc REL_12_16 PGbin 12.16-1 UCRT64 x64 windows-latest Release
+          # https://github.com/AndreMikulec/plr/actions/runs/6166564347/job/16737092810#step:33:773
+          # #
+          # FUTURE - investigate and solve
+          # config_info.c:128:54: error: incomplete universal character name \uc
+
+##        - os: windows-latest
+##          GithubActionsIgnoreFail: false
+##          compilerEnv: UCRT64
+##          shellEnv: msys2 {0}
+##          compilerExe: gcc
+##          Platform: x64
+##          Configuration: Release
+##          #
+##          rversion: 4.3.1
+##          R_HOME: 'D:\RINSTALL'
+##          R_ARCH: /x64
+##          #
+##          pgSRCversion: REL_12_16
+##          PG_SOURCE: 'D:\PGSOURCE'
+##          buildpgFromSRC: true
+##          buildpgFromSRCmethod: make
+##          PG_HOME: 'D:\PGINSTALL'
+##          #
+##          pgWINversion: 12.16-1
+##          #
+##          MSYS2testonpgWIN: true
+
+##        - os: windows-latest
+##          GithubActionsIgnoreFail: false
+##          compilerEnv: UCRT64
+##          shellEnv: msys2 {0}
+##          compilerExe: gcc
+##          Platform: x64
+##          Configuration: Release
+##          #
+##          rversion: 4.3.1
+##          R_HOME: 'D:\RINSTALL'
+##          R_ARCH: /x64
+##          #
+##          pgSRCversion: REL_11_21
+##          PG_SOURCE: 'D:\PGSOURCE'
+##          buildpgFromSRC: true
+##          buildpgFromSRCmethod: make
+##          PG_HOME: 'D:\PGINSTALL'
+##          #
+##          pgWINversion: 11.21-1
+##          #
+##          MSYS2testonpgWIN: true
+
+          - os: windows-latest
+            GithubActionsIgnoreFail: false
+            compilerEnv: MINGW32
+            shellEnv: msys2 {0}
+            compilerExe: gcc
+            Platform: x86
+            Configuration: Release
+            #
+            rversion: 4.1.3
+            R_HOME: 'D:\RINSTALL'
+            R_ARCH: /i386
+            #
+            pgSRCversion: REL_10_23
+            PG_SOURCE: 'D:\PGSOURCE'
+            buildpgFromSRC: true
+            buildpgFromSRCmethod: make
+            PG_HOME: 'D:\PGINSTALL'
+            #
+            pgWINversion: 10.23-1
+            #
+            MSYS2testonpgWIN: true
+
+    defaults:
+      run:
+        shell: ${{ matrix.shellEnv || 'bash' }}
+
+    steps:
+
+      - name: Windows Machine Stats systeminfo
+        if: ${{ matrix.os == 'windows-latest' }}
+        shell: cmd
+        run: |
+          systeminfo
+
+      - name: Prepare to Download Files from Github
+        shell: powershell
+        run: |
+          git config --global core.autocrlf input
+          git config --global advice.detachedHead false
+
+      - name: Matrix Variables
+        if: matrix.os == 'windows-latest'
+        shell: powershell
+        run: |
+          # systeminfo
+          echo "${{ matrix.compilerEnv }} on ${{ matrix.os }}"
+          # JUL 2023 - only THIS exists in Github Actions
+          if( Test-Path "C:\Program Files\PostgreSQL\14" ) {
+            "PostgreSQL for Windows x64-14 exists."
+          } else {
+            "PostgreSQL for Windows x64-14 does not exist."
+          }
+          function Set-EnvVar {param($X)     Add-Content -Path ${env:GITHUB_ENV} -Value "$X"}
+          #
+          ${env:HEAD8_GITHUB_SHA} = "${env:GITHUB_SHA}".SubString(0,8)
+          Set-EnvVar "HEAD8_GITHUB_SHA=${env:HEAD8_GITHUB_SHA}"
+
+          echo "HEAD8_GITHUB_SHA: ${env:HEAD8_GITHUB_SHA}"
+
+          ${env:os} = "${{ matrix.os }}"
+          if("${env:os}" -eq ""){${env:os} = "notset"}
+          Set-EnvVar "os=${env:os}"
+
+          echo "os: ${env:os}"
+
+          ${env:Platform} = "${{ matrix.Platform }}"
+          if("${env:Platform}" -eq ""){${env:Platform} = "notset"}
+          Set-EnvVar "Platform=${env:Platform}"
+
+          echo "Platform: ${env:Platform}"
+
+          ${env:Configuration} = "${{ matrix.Configuration }}"
+          if("${env:Configuration}" -eq ""){${env:Configuration} = "notset"}
+          Set-EnvVar "Configuration=${env:Configuration}"
+
+          echo "Configuration: ${env:Configuration}"
+
+          ${env:rversion} = "${{ matrix.rversion }}"
+          if("${env:rversion}" -eq ""){${env:rversion} = "notset"}
+          Set-EnvVar "rversion=${env:rversion}"
+
+          echo "rversion: ${env:rversion}"
+
+          ${env:rmajor} = "notset"
+          ${env:rminor} = "notset"
+          ${env:rpatch} = "notset"
+          ${env:rversionnumeric} = "notset"
+
+          $matches = @()
+          if("${env:rversion}" -ne "notset") {
+            # R-major.minor.patch
+            # R-major.minor.patchpatched
+            if(${env:rversion} -match '(\d+)')             { ${env:rmajor} = $matches[1]; $matches = @() }
+            if(${env:rversion} -match '\d+[.](\d+)')       { ${env:rminor} = $matches[1]; $matches = @() }
+            if(${env:rversion} -match '\d+[.]\d+[.](\d+)') { ${env:rpatch} = $matches[1]; $matches = @() }
+            if(${env:rversion} -match '\d+[.]\d+[.](\d+)') {
+              ${env:rversionnumeric} = ([int]"${env:rmajor}" * 10000) + ([int]"${env:rminor}" * 100) + ([int]"${env:rpatch}")
+            }
+            $matches = @()
+          }
+          if("${env:rversion}" -match 'devel') {
+            ${env:rmajor} = "devel"
+            ${env:rminor} = "devel"
+            ${env:rpatch} = "devel"
+            ${env:rversionnumeric} = "999999"
+          }
+          $matches = @()
+
+          Set-EnvVar "rmajor=${env:rmajor}"
+          Set-EnvVar "rminor=${env:rminor}"
+          Set-EnvVar "rpatch=${env:rpatch}"
+          Set-EnvVar "rversionnumeric=${env:rversionnumeric}"
+
+          echo "         rmajor: ${env:rmajor}"
+          echo "         rminor: ${env:rminor}"
+          echo "         rpatch: ${env:rpatch}"
+          echo "rversionnumeric: ${env:rversionnumeric}"
+
+          ${env:rversionlong} = "notset"
+          # derived (this will be changed FAR FAR below)
+          ${env:rversionlong} = ${env:rversion}
+          Set-EnvVar "rversionlong=${env:rversionlong}"
+
+          ${env:bit} = "notset"
+                                           # derived
+          if("${env:Platform}" -eq "x64")  { ${env:bit} = "64" }
+          if("${env:Platform}" -eq "x86")  { ${env:bit} = "32" }
+          if("${env:Platform}" -eq "notset") { ${env:bit} = "notset" }
+          Set-EnvVar "bit=${env:bit}"
+
+          echo "bit: ${env:bit}"
+
+          ${env:R_HOME} = "${{ matrix.R_HOME }}"
+          if("${env:R_HOME}" -eq ""){${env:R_HOME} = "notset"}
+          Set-EnvVar "R_HOME=${env:R_HOME}"
+
+          echo "R_HOME: ${env:R_HOME}"
+
+          ${env:R_ARCH} = "${{ matrix.R_ARCH }}"
+          if("${env:R_ARCH}" -eq ""){${env:R_ARCH} = "notset"}
+          Set-EnvVar "R_ARCH=${env:R_ARCH}"
+
+          echo "R_ARCH: ${env:R_ARCH}"
+
+          ${env:compilerEnv} = "${{ matrix.compilerEnv }}"
+          if("${env:compilerEnv}" -eq ""){${env:compilerEnv} = "notset"}
+          Set-EnvVar "compilerEnv=${env:compilerEnv}"
+
+          echo "compilerEnv: ${env:compilerEnv}"
+
+          ${env:compilerClass} = "notset"
+          if("${env:compilerEnv}" -in "MING64", "MINGW32", "UCRT64", "CLANG32", "CLANG64", "CLANGARM64") {
+            ${env:compilerClass} = "MSYS2"
+          }
+          if("${env:compilerEnv}" -eq "cygwin") {
+            ${env:compilerClass} = "cygwin"
+          }
+          if("${env:compilerEnv}" -eq "msvc") {
+            ${env:compilerClass} = "msvc"
+          }
+          Set-EnvVar "compilerClass=${env:compilerClass}"
+
+          echo "compilerClass: ${env:compilerClass}"
+
+
+          ${env:compilerExe} = "${{ matrix.compilerExe }}"
+          if("${env:compilerExe}" -eq ""){${env:compilerExe} = "notset"}
+          Set-EnvVar "compilerExe=${env:compilerExe}"
+
+          echo "compilerExe: ${env:compilerExe}"
+
+          ${env:mingw_env} = "notset"
+          if ( "${{ matrix.compilerEnv }}" -eq "MINGW64"    ) { ${env:mingw_env} = "x86_64" }
+          if ( "${{ matrix.compilerEnv }}" -eq "MINGW32"    ) { ${env:mingw_env} = "i686" }
+          if ( "${{ matrix.compilerEnv }}" -eq "UCRT64"     ) { ${env:mingw_env} = "ucrt-x86_64" }
+          if ( "${{ matrix.compilerEnv }}" -eq "CLANG32"    ) { ${env:mingw_env} = "clang-i686" }
+          if ( "${{ matrix.compilerEnv }}" -eq "CLANG64"    ) { ${env:mingw_env} = "clang-x86_64" }
+          if ( "${{ matrix.compilerEnv }}" -eq "CLANGARM64" ) { ${env:mingw_env} = "clang-aarch64" }
+          if ( "${{ matrix.compilerEnv }}" -eq "notset"     ) { ${env:mingw_env} = "notset" }
+          Set-EnvVar "mingw_env=${env:mingw_env}"
+
+          echo "mingw_env: ${env:mingw_env}"
+
+          ${env:MINGW_PACKAGE_PREFIX} = "notset"
+          if ("${{ env.mingw_env }}" -ne "notset") { ${env:MINGW_PACKAGE_PREFIX} = "mingw-w64-${env:mingw_env}" }
+          if ("${{ env.mingw_env }}" -eq "notset") { ${env:MINGW_PACKAGE_PREFIX} = "notset" }
+          Set-EnvVar "MINGW_PACKAGE_PREFIX=${env:MINGW_PACKAGE_PREFIX}"
+
+          echo "MINGW_PACKAGE_PREFIX: ${env:MINGW_PACKAGE_PREFIX}"
+
+          ${env:R_ARCHplat} = "notset"
+          if("${env:R_ARCH}" -eq "/x64")    { ${env:R_ARCHplat} =    "x64" }
+          if("${env:R_ARCH}" -eq "/i386")   { ${env:R_ARCHplat} =   "i386" }
+          if("${env:R_ARCH}" -eq "notset")  { ${env:R_ARCHplat} = "notset" }
+          Set-EnvVar "R_ARCHplat=${env:R_ARCHplat}"
+
+          echo "R_ARCHplat: ${env:R_ARCHplat}"
+
+          ${env:pgSRCversion} = "${{ matrix.pgSRCversion }}"
+          if("${env:pgSRCversion}" -eq ""){${env:pgSRCversion} = "notset"}
+          Set-EnvVar "pgSRCversion=${env:pgSRCversion}"
+
+          echo "pgSRCversion: ${env:pgSRCversion}"
+
+          ${env:PG_SOURCE} = "${{ matrix.PG_SOURCE }}"
+          if("${env:PG_SOURCE}" -eq ""){${env:PG_SOURCE} = "notset"}
+          Set-EnvVar "PG_SOURCE=${env:PG_SOURCE}"
+
+          echo "PG_SOURCE: ${env:PG_SOURCE}"
+
+          ${env:buildpgFromSRC} = "${{ matrix.buildpgFromSRC }}"
+          if("${env:buildpgFromSRC}" -eq ""){${env:buildpgFromSRC} = "notset"}
+          Set-EnvVar "buildpgFromSRC=${env:buildpgFromSRC}"
+
+          echo "buildpgFromSRC: ${env:buildpgFromSRC}"
+
+          ${env:buildpgFromSRCmethod} = "${{ matrix.buildpgFromSRCmethod }}"
+          if("${env:buildpgFromSRCmethod}" -eq ""){${env:buildpgFromSRCmethod} = "notset"}
+          Set-EnvVar "buildpgFromSRCmethod=${env:buildpgFromSRCmethod}"
+
+          echo "buildpgFromSRCmethod: ${env:buildpgFromSRCmethod}"
+
+          ${env:buildpgANDplrInSRCcontrib} = "${{ matrix.buildpgANDplrInSRCcontrib }}"
+          if("${env:buildpgANDplrInSRCcontrib}" -eq ""){${env:buildpgANDplrInSRCcontrib} = "notset"}
+          Set-EnvVar "buildpgANDplrInSRCcontrib=${env:buildpgANDplrInSRCcontrib}"
+
+          echo "buildpgANDplrInSRCcontrib: ${env:buildpgANDplrInSRCcontrib}"
+
+          ${env:PG_HOME} = "${{ matrix.PG_HOME }}"
+          if("${env:PG_HOME}" -eq ""){${env:PG_HOME} = "notset"}
+          Set-EnvVar "PG_HOME=${env:PG_HOME}"
+
+          echo "PG_HOME: ${env:PG_HOME}"
+
+          ${env:MSYS2testonpgWIN} = "${{ matrix.MSYS2testonpgWIN }}"
+          if("${env:MSYS2testonpgWIN}" -eq ""){${env:MSYS2testonpgWIN} = "notset"}
+          Set-EnvVar "MSYS2testonpgWIN=${env:MSYS2testonpgWIN}"
+
+          echo "MSYS2testonpgWIN: ${env:MSYS2testonpgWIN}"
+
+          ${env:pgWINversion} = "${{ matrix.pgWINversion }}"
+          if("${env:pgWINversion}" -eq ""){${env:pgWINversion} = "notset"}
+          Set-EnvVar "pgWINversion=${env:pgWINversion}"
+
+          echo "pgWINversion: ${env:pgWINversion}"
+
+          ${env:pgWINServiceNameHostDefault} = "notset"
+          ${env:pgWINServiceNameHostDefault} = (Get-Service -ErrorAction SilentlyContinue | where-object {$_.name -like "*postgres*"}).Name
+          echo "pgWINServiceNameHostDefault: ${env:pgWINServiceNameHostDefault}"
+          Set-EnvVar "pgWINServiceNameHostDefault=${env:pgWINServiceNameHostDefault}"
+
+          ${env:pgwinmajor} = "notset"
+          # if any, strip off the: right-most part dot, then numbers, then one hyphen, then numbers.
+          # e.g.  9.6.24-1 becomes  9.6
+          # e.g. 13.11-3   becomes 13
+          if("${env:pgWINversion}" -ne "notset") { ${env:pgwinmajor} = ${env:pgWINversion} -replace "[.]\d+-\d+$" }
+          if("${env:pgWINversion}" -eq "notset") {
+            if("${env:pgWINServiceNameHostDefault}" -match "(\d+[.]{0,1}\d+$)") {
+              # if (1) no entry "pgWINversion: whatever" and yes entry "MSYS2testonpgWIN: true"
+              # then THIS(14) is the default TESTING(14) "MSYS2testonpgWIN PostgreSQL"
+              # 9.6
+              # 13
+              ${env:pgwinmajor} = $matches[1]; $matches = @()
+              # override
+              ${env:pgWINversion} = "NODOWNLOAD"
+            }
+          }
+          Set-EnvVar "pgwinmajor=${env:pgwinmajor}"
+          Set-EnvVar "pgWINversion=${env:pgWINversion}"
+
+          echo "pgwinmajor: ${env:pgwinmajor}"
+          echo "pgWINversion: ${env:pgWINversion}"
+
+          ${env:pgWINversionlong} = "notset"
+          if("${env:Platform}" -eq "x86"  -and "${env:pgWINversion}" -ne "notset") {
+            ${env:pgWINversionlong} = "postgresql-${env:pgWINversion}-windows"
+          }
+          if("${env:Platform}" -eq "x64" -and "${env:pgWINversion}" -ne "notset") {
+            ${env:pgWINversionlong} = "postgresql-${env:pgWINversion}-windows-x64"
+          }
+          if("${env:Platform}" -eq "notset" -or "${env:pgWINversion}" -eq "notset") {
+            ${env:pgWINversionlong} = "notset"
+          }
+          Set-EnvVar "pgWINversionlong=${env:pgWINversionlong}"
+
+          echo "pgWINversionlong: ${env:pgWINversionlong}"
+
+          if("${env:pgWINversionlong}" -ne "notset") {
+            ${env:ENTDB_PG_DOWNLOAD_URL} = "http://get.enterprisedb.com/postgresql/${env:pgWINversionlong}.exe"
+          }
+          if("${env:pgWINversionlong}" -eq "notset") {
+            ${env:ENTDB_PG_DOWNLOAD_URL} = "notset"
+          }
+          Set-EnvVar "ENTDB_PG_DOWNLOAD_URL=${env:ENTDB_PG_DOWNLOAD_URL}"
+
+          echo "ENTDB_PG_DOWNLOAD_URL: ${env:ENTDB_PG_DOWNLOAD_URL}"
+
+          ${env:PGVER2} = "notset"
+          # Prep for Install PostgreSQL for Windows (if applicable)
+          ${env:PGVER2} = ${env:pgwinmajor}
+          Set-EnvVar "PGVER2=${env:PGVER2}"
+
+          echo "PGVER2: ${env:PGVER2}"
+
+          ${env:PGBIN2}  = "notset"
+          ${env:PGDATA2} = "notset"
+          ${env:PGROOT2} = "notset"
+          if("${env:Platform}" -eq "x64") {
+            ${env:PGBIN2}  = "C:\Program Files\PostgreSQL\${env:pgwinmajor}\bin"
+            ${env:PGDATA2} = "C:\Program Files\PostgreSQL\${env:pgwinmajor}\data"
+            ${env:PGROOT2} = "C:\Program Files\PostgreSQL\${env:pgwinmajor}"
+          }
+          if("${env:Platform}" -eq "x86") {
+            ${env:PGBIN2}  = "C:\Program Files (x86)\PostgreSQL\${env:pgwinmajor}\bin"
+            ${env:PGDATA2} = "C:\Program Files (x86)\PostgreSQL\${env:pgwinmajor}\data"
+            ${env:PGROOT2} = "C:\Program Files (x86)\PostgreSQL\${env:pgwinmajor}"
+          }
+          if("${env:Platform}" -eq "notset") {
+            ${env:PGBIN2}  = "notset"
+            ${env:PGDATA2} = "notset"
+            ${env:PGROOT2} = "notset"
+          }
+          Set-EnvVar "PGBIN2=${env:PGBIN2}"
+          Set-EnvVar "PGDATA2=${env:PGDATA2}"
+          Set-EnvVar "PGROOT2=${env:PGROOT2}"
+
+          echo " PGBIN2: ${env:PGBIN2}"
+          echo "PGDATA2: ${env:PGDATA2}"
+          echo "PGROOT2: ${env:PGROOT2}"
+
+
+      - name: Matrix Windows Platform Specific Variables
+        if: ${{ env.os == 'windows-latest' && ( env.compilerClass == 'MSYS2' || env.compilerClass == 'msvc' ) }}
+        shell: powershell
+        run: |
+          function Set-EnvVar {param($X)     Add-Content -Path ${env:GITHUB_ENV} -Value "$X"}
+
+          # enhances and overrides #
+          ${env:rversionlong} = "${{ env.rversionlong }}-win"
+
+          $matches = @()
+          if( "${{ env.rversion }}" -match "2.11.0|2.11.1") {
+            ${env:rversionlong} = "${{ env.rversion }}-win${{ env.bit }}"
+          }
+          $matches = @()
+          ${env:rversionlong} = "R-${env:rversionlong}"
+
+          Set-EnvVar "rversionlong=${env:rversionlong}"
+
+          echo "rversionlong: ${env:rversionlong}"
+
+          # CRAN download URL
+          ${env:CRAN_R_DOWNLOAD_URL} ="notset"
+
+          $matches = @()
+          if(-not ("${env:rversionlong}" -match 'patched|devel')) {
+            if([int]"${{ env.rversionnumeric }}" -ge 30600 ) {
+              ${env:CRAN_R_DOWNLOAD_URL} = "https://cran.r-project.org/bin/windows/base/old/${{ env.rversion }}/${env:rversionlong}.exe"
+            }
+
+            if([int]"${{ env.rversionnumeric }}" -lt 30600 ) {
+              ${env:CRAN_R_DOWNLOAD_URL} = "https://cran-archive.r-project.org/bin/windows/base/old/${{ env.rversion }}/${env:rversionlong}.exe"
+            }
+          }
+          $matches = @()
+          if("${env:rversionlong}" -match 'patched|devel') {
+            ${env:CRAN_R_DOWNLOAD_URL} = "https://cran.r-project.org/bin/windows/base/${env:rversionlong}.exe"
+          }
+          $matches = @()
+          Set-EnvVar "CRAN_R_DOWNLOAD_URL=${env:CRAN_R_DOWNLOAD_URL}"
+
+          echo "CRAN_R_DOWNLOAD_URL: ${env:CRAN_R_DOWNLOAD_URL}"
+
+      - name: Checkout Code of This Repository
+        uses: actions/checkout@v3
+
+      # running Meson on GitHub Actions will end up using GCC rather than MSVC
+      #
+      # His fix .
+      # https://dvdhrm.github.io/2021/04/21/meson-msvc-github-actions/
+      #
+      # `x64` for 64-bit x86 machines, `x86` for 32-bit x86 machines.
+      # https://github.com/bus1/cabuild/blob/8c91ebf06b7a5f8405cf93c89a6928e4c76967e0/action/msdevshell/action.yml
+      - name: Prepare Github Actions, MSVC, and Meson
+        if: ${{ env.os == 'windows-latest' && env.compilerClass == 'msvc' }}
+        uses: bus1/cabuild/action/msdevshell@v1
+        with:
+          # msvc ARCHITECTURE
+          architecture: ${{ env.Platform }}
+
+      - name: Checkout PostgreSQL Code
+        if: ${{ env.pgSRCversion != 'notset' }}
+        uses: actions/checkout@v3
+        with:
+          repository: 'postgres/postgres'
+
+          # The branch, tag or SHA to checkout. When checking out the repository that
+          # triggered a workflow, this defaults to the reference or SHA for that event.
+          # Otherwise, uses the default branch.
+
+          # # statics
+          # REL_16_BETA2
+          #   19508f4
+          #   19508f4763b6e55baae788af000ee47e74d24370
+          # REL_10_23
+          #   02991e7
+          #   02991e79f8f58bc208f05dcc8af0c62dbe0a6ea4
+
+          # # non-statics
+          # master
+          # REL_16_STABLE
+          # REL_15_STABLE
+          #
+          ref: '${{ env.pgSRCversion }}'
+          # Relative path under $GITHUB_WORKSPACE to place the repository
+          path: PGSOURCE
+
+      - name: Windows Move PostgreSQL Code
+        if: ${{ env.os == 'windows-latest' && env.pgSRCversion != 'notset' }}
+        shell: powershell
+        run: |
+          Move-Item -Path PGSOURCE -Destination ${{ env.PG_SOURCE }}
+          Get-ChildItem                         ${{ env.PG_SOURCE }}
+
+      # I do not want to cache "R for Windows devel version".
+      #
+      # Manage my caches
+      # https://github.com/GITHUBUSER/GITHUBREPOSITORY/actions/caches
+      #
+      # TODO - possiblity of a FUTURE workaround
+      # https://github.com/actions/cache/blob/main/tips-and-workarounds.md#update-a-cache
+      #
+      - name: Cache R-x.y.z Windows Installer Exe
+        if: ${{ env.os == 'windows-latest' && ( env.compilerClass == 'MSYS2' || env.compilerClass == 'msvc' ) && env.rversion != 'devel' }}
+        uses: actions/cache@v3
+        id: cacheRWindowsInstallerExe
+        with:
+          path: ${{ env.rversionlong }}.exe
+          key:  ${{ env.rversionlong }}.exe
+        env:
+          SEGMENT_DOWNLOAD_TIMEOUT_MINS: 1
+
+      - name: Cache PostgreSQL for Windows
+        if: >-
+          ${{ env.os == 'windows-latest' && ( env.compilerClass == 'MSYS2' || env.compilerClass == 'msvc' ) && env.pgWINversion != 'notset' &&
+          (( env.PGVER2 == '14' && env.Platform == 'x86' ) || ( env.PGVER2 != '14' ))
+          }}
+        uses: actions/cache@v3
+        id: cachePGWindowsInstallerExe
+        with:
+          path: ${{ env.pgWINversionlong }}.exe
+          key:  ${{ env.pgWINversionlong }}.exe
+        env:
+          SEGMENT_DOWNLOAD_TIMEOUT_MINS: 10
+
+      - name: Cache GNU diffutils for Test on PostgreSQL for Windows
+        if: ${{ ( env.os == 'windows-latest' && env.compilerClass == 'MSYS2' && env.MSYS2testonpgWIN == 'true' ) || ( env.os == 'windows-latest' && env.compilerClass == 'msvc' ) }}
+        uses: actions/cache@v3
+        id: cacheDiffutilsZip
+        with:
+          path: diffutils-2.8.7-1-bin.zip
+          key:  diffutils-2.8.7-1-bin.zip
+        env:
+          SEGMENT_DOWNLOAD_TIMEOUT_MINS: 1
+
+      - name: Cache pkgconfiglite for Compile using msvc and meson
+        if: ${{ env.os == 'windows-latest' && env.compilerClass == 'msvc' }}
+        uses: actions/cache@v3
+        id: cachePkgConfigLiteZip
+        with:
+          path: pkg-config-lite-0.28-1_bin-win32.zip
+          key:  pkg-config-lite-0.28-1_bin-win32.zip
+        env:
+          SEGMENT_DOWNLOAD_TIMEOUT_MINS: 1
+
+      - name: Cache winflexbison for Compile using msvc
+        if: ${{ env.os == 'windows-latest' && env.compilerClass == 'msvc' }}
+        uses: actions/cache@v3
+        id: cacheWinFlexBisonZip
+        with:
+          path: win_flex_bison-2.5.24.zip
+          key:  win_flex_bison-2.5.24.zip
+        env:
+          SEGMENT_DOWNLOAD_TIMEOUT_MINS: 1
+
+      - name: Cache meson for Compile using msvc and meson
+        if: ${{ env.os == 'windows-latest' && env.compilerClass == 'msvc' }}
+        uses: actions/cache@v3
+        id: cacheMesonMsi
+        with:
+          path: meson-1.2.1-64.msi
+          key:  meson-1.2.1-64.msi
+        env:
+          SEGMENT_DOWNLOAD_TIMEOUT_MINS: 1
+
+      # Notice
+      # Path R-2.11.1-x64
+      # Download Name -R-2.11.1-win64.exe
+      # https://cran-archive.r-project.org/bin/windows/base/old/2.11.1/R-2.11.1-win64.exe
+      # Path R-2.11.1
+      # Download Name - R-2.11.1-win32.exe
+      # https://cran-archive.r-project.org/bin/windows/base/old/2.11.1/R-2.11.1-win32.exe
+      #
+      # five seconds
+      - name: Download R for Windows R-x.y.z R-rmajor.rminor.rpatch
+        if: >-
+          ${{ env.os == 'windows-latest' && ( env.compilerClass == 'MSYS2' || env.compilerClass == 'msvc' ) &&
+          steps.cacheRWindowsInstallerExe.outputs.cache-hit != 'true'
+          }}
+        uses: suisei-cn/actions-download-file@v1.4.0
+        id: downloadfileRforWindows
+        with:
+          url: ${{ env.CRAN_R_DOWNLOAD_URL }}
+
+      - name: Download PostgreSQL for Windows
+        if: >-
+          ${{ env.os == 'windows-latest' && ( env.compilerClass == 'MSYS2' || env.compilerClass == 'msvc' ) && env.pgWINversion != 'notset' &&
+          (( env.PGVER2 == '14' && env.Platform == 'x86' ) || ( env.PGVER2 != '14' )) &&
+          steps.cachePGWindowsInstallerExe.outputs.cache-hit != 'true'
+          }}
+        uses: suisei-cn/actions-download-file@v1.4.0
+        id: downloadfilePGforWindows
+        with:
+          url: ${{ env.ENTDB_PG_DOWNLOAD_URL }}
+
+#     # The "crazy-max/ghaction-chocolatey@v2" "install SOMEHING_AT_SOURCEFORGE" file download often times-out.
+#     - name: Choco Install GNU diffutils for Test on PostgreSQL for Windows
+#       uses: crazy-max/ghaction-chocolatey@v2
+#       with:
+#         args: install diffutils
+
+      - name: Download GNU diffutils for Test on PostgreSQL for Windows
+        if: ${{ ( ( env.os == 'windows-latest' && env.compilerClass == 'MSYS2' && env.MSYS2testonpgWIN == 'true' ) || ( env.os == 'windows-latest' && env.compilerClass == 'msvc' ) ) &&
+          steps.cacheDiffutilsZip.outputs.cache-hit != 'true'
+          }}
+        uses: suisei-cn/actions-download-file@v1.4.0
+        id: downloadDiffutilsZip
+        with:
+          retry-times: 1
+          url: https://zenlayer.dl.sourceforge.net/project/gnuwin32/diffutils/2.8.7-1/diffutils-2.8.7-1-bin.zip
+
+      - name: Download pkgconfiglite for Compile using msvc and meson
+        if: >-
+          ${{ env.os == 'windows-latest' && env.compilerClass == 'msvc' &&
+          steps.cachePkgConfigLiteZip.outputs.cache-hit != 'true'
+          }}
+        uses: suisei-cn/actions-download-file@v1.4.0
+        id: downloadPkgConfigLiteZip
+        with:
+          retry-times: 1
+          url: http://downloads.sourceforge.net/project/pkgconfiglite/0.28-1/pkg-config-lite-0.28-1_bin-win32.zip
+
+      - name: Download winflexbison for Compile using msvc
+        if: >-
+          ${{ env.os == 'windows-latest' && env.compilerClass == 'msvc' &&
+          steps.cacheWinFlexBisonZip.outputs.cache-hit != 'true'
+          }}
+        uses: suisei-cn/actions-download-file@v1.4.0
+        id: downloadWinFlexBisonZip
+        with:
+          retry-times: 1
+          url: https://sourceforge.net/projects/winflexbison/files/win_flex_bison-2.5.24.zip
+
+
+      - name: Download meson for Compile using msvc and meson
+        if: >-
+          ${{ env.os == 'windows-latest' && env.compilerClass == 'msvc' &&
+          steps.cacheMesonMsi.outputs.cache-hit != 'true'
+          }}
+        uses: suisei-cn/actions-download-file@v1.4.0
+        id: downloadMesonMsi
+        with:
+          retry-times: 1
+          url: https://github.com/mesonbuild/meson/releases/download/1.2.1/meson-1.2.1-64.msi
+
+      - name: Install R for Windows R-x.y.z R-rmajor.rminor.rpatch
+        if: ${{ env.os == 'windows-latest' && ( env.compilerClass == 'MSYS2' || env.compilerClass == 'msvc' ) }}
+        env:
+          R_HOME: ${{ env.R_HOME }}
+          R_ARCHplat: ${{ env.R_ARCHplat }}
+        shell: cmd
+        run: |
+          echo on
+          echo R_HOME: %R_HOME%
+          echo R_ARCHplat: %R_ARCHplat%
+          rem need "main" for the GUIs and command line utilites to work
+          rem A comma at the end is O.K
+          rem Component "notset" is ignored
+          "${{ env.rversionlong }}.exe" /VERYSILENT /COMPONENTS=main,%R_ARCHplat% /DIR=%R_HOME% /NOICONS /TASKS=
+          dir "%R_HOME%"
+
+      # Github Actions provided PostgreSQL x64-14 (as of SEPTEMBER 2023)
+      #
+      # # AUGUST 2023
+      # # The PL/R extension was built using PostreSQL 15
+      # ServiceName postgresql-x64-14
+      # Version 14.8
+      # ServiceStatus Stopped
+      # ServiceStartType Disabled
+      # EnvironmentVariables PGBIN=C:\Program Files\PostgreSQL\14\bin
+      # PGDATA=C:\Program Files\PostgreSQL\14\data
+      # PGROOT=C:\Program Files\PostgreSQL\14
+      # Path C:\Program Files\PostgreSQL\14
+      # UserName postgres
+      # Password root
+      # #
+      # https://github.com/actions/runner-images/blob/main/images/win/Windows2022-Readme.md
+      # https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-software
+      #
+      - name: From Disabled, Enable PostgreSQL x64-14 for Windows and Start and Stop
+        if: >-
+          ${{ env.os == 'windows-latest' && ( env.compilerClass == 'MSYS2' && env.MSYS2testonpgWIN == 'true' || env.compilerClass == 'msvc' ) &&
+          env.PGVER2 == '14' && env.Platform == 'x64'
+          }}
+        shell: cmd
+        run: |
+          echo on
+          sc config "postgresql-x64-14" start= auto
+          net start  postgresql-x64-14
+          net stop   postgresql-x64-14
+
+      - name: Install PostgreSQL for Windows and Stop PostgreSQL
+        if: >-
+          ${{ env.os == 'windows-latest' && ( env.compilerClass == 'MSYS2' || env.compilerClass == 'msvc' ) && env.pgWINversion != 'notset' &&
+          (( env.PGVER2 == '14' && env.Platform == 'x86' ) || ( env.PGVER2 != '14' ))
+          }}
+        env:
+          PGVER2: ${{ env.PGVER2 }}
+          PGROOT2: ${{ env.PGROOT2 }}
+          Platform: ${{ env.Platform }}
+        shell: cmd
+        run: |
+          echo on
+          "${{ env.pgWINversionlong }}.exe" --unattendedmodeui none --mode unattended --enable-components server,commandlinetools --disable-components pgAdmin,stackbuilder --superpassword "root" > nul
+          rem postgresql-15.3-4-windows-x64.exe
+          rem "C:\Program Files\PostgreSQL\15"
+          rem "C:\Program Files\PostgreSQL\15\data"
+          rem root
+          rem 5432
+          rem "Installation Directory: C:\Program Files\PostgreSQL\15"
+          rem "Server Installation Directory: C:\Program Files\PostgreSQL\15"
+          rem "Data Directory: C:\Program Files\PostgreSQL\15\data"
+          rem "Database Port: 5432"
+          rem "Database Superuser: postgres"
+          rem "Operating System Account: NT AUTHORITY\NetworkService"
+          rem "Database Service: postgresql-x64-15"
+          rem "Command Line Tools Installation Directory: C:\Program Files\PostgreSQL\15"
+          rem "Installation Log: C:\Users\AnonymousUser\AppData\Local\Temp\install-postgresql.log"
+          rem
+          rem "Starting the database server"
+          rem
+          rem Installation will also start PostgreSQL
+          if "%Platform%"=="x64" (net stop postgresql-x64-%PGVER2%)
+          if "%Platform%"=="x86" (net stop postgresql-%PGVER2%)
+          if "%Platform%"=="notset" (echo Platform is not set, therefore no net stop happens.)
+          dir "%PGROOT2%"
+
+      # https://wiki.postgresql.org/wiki/Meson
+      #   NOTE - (for PostgreSQL) winflexbison - fails with a general error. (see OTHER step)
+      #   NOTE - (for testing) diffutils - times out - doing a custom install instead (see OTHER step)
+      #   NOTE - (for meson) pkgconfiglite - times out - doing a custom install instead (see OTHER step)
+      #   NOTE - meson - fails with msiexec.exe Exit code was '3010' (see OTHER step)
+      #   NOTE - 7z is provided by Github Actions
+      - name: Choco Install support software about PL/R compiling using msvc for Windows
+        if: ${{ env.os == 'windows-latest' && env.compilerClass == 'msvc' }}
+        # Keep v2.  v2.2.0 may have connection to Sourceforge problems
+        uses: crazy-max/ghaction-chocolatey@v2
+        with:
+          args: >-
+            install sed gzip strawberryperl
+            grep
+
+      # Choco Install GNU diffutils
+      # BUT the "crazy-max/ghaction-chocolatey@v2" "install diffutils" file download often times-out
+      - name: Extract Diffuntils and add Diffuntils bin directory to the PATH for Test on PostgreSQL for Windows
+        if: ${{ ( env.os == 'windows-latest' && env.compilerClass == 'MSYS2' && env.MSYS2testonpgWIN == 'true' ) || ( env.os == 'windows-latest' && env.compilerClass == 'msvc' ) }}
+        shell: cmd
+        run: |
+          rem MKDIR creates any intermediate directories in the path, if needed.
+          mkdir                                "C:\OTHERBIN\diffutils"
+          rem 7z is provided by Github Actions
+          7z x  diffutils-2.8.7-1-bin.zip    -o"C:\OTHERBIN\diffutils"
+          copy  diffutils-2.8.7-1-bin.zip      "C:\OTHERBIN\diffutils"
+          dir                                  "C:\OTHERBIN\diffutils"
+          rem - man7.org/linux/man-pages/man1/printf.1.html
+          printf                               "C:\\OTHERBIN\\diffutils\\bin" >> %GITHUB_PATH%
+
+      # Choco Install pkgconfiglite
+      # BUT the "crazy-max/ghaction-chocolatey@v2" "install pkgconfiglite" file download often times-out
+      - name: Extract pkgconfiglite and add pkgconfiglite bin directory to the PATH for Compile using msvc and meson
+        if: ${{ env.os == 'windows-latest' && env.compilerClass == 'msvc' }}
+        shell: cmd
+        run: |
+          rem MKDIR creates any intermediate directories in the path, if needed.
+          mkdir                                           "C:\OTHERBIN\pkgconfiglite"
+          rem 7z is provided by Github Actions
+          7z x  pkg-config-lite-0.28-1_bin-win32.zip    -o"C:\OTHERBIN\pkgconfiglite"
+          copy  pkg-config-lite-0.28-1_bin-win32.zip      "C:\OTHERBIN\pkgconfiglite"
+          dir                                             "C:\OTHERBIN\pkgconfiglite"
+          rem - man7.org/linux/man-pages/man1/printf.1.html
+          printf                                          "C:\\OTHERBIN\\pkgconfiglite\\pkg-config-lite-0.28-1\\bin" >> %GITHUB_PATH%
+
+      # Choco Install winflexbison
+      # BUT the "crazy-max/ghaction-chocolatey@v2" "install pkgconfiglite" file download often times-out
+      - name: Extract winflexbison and add the winflexbison directory to the PATH for Compile using msvc
+        if: ${{ env.os == 'windows-latest' && env.compilerClass == 'msvc' }}
+        shell: cmd
+        run: |
+          rem MKDIR creates any intermediate directories in the path, if needed.
+          mkdir                                           "C:\OTHERBIN\winflexbison"
+          rem 7z is provided by Github Actions
+          7z x  win_flex_bison-2.5.24.zip               -o"C:\OTHERBIN\winflexbison"
+          copy  win_flex_bison-2.5.24.zip                 "C:\OTHERBIN\winflexbison"
+          dir                                             "C:\OTHERBIN\winflexbison"
+          rem - man7.org/linux/man-pages/man1/printf.1.html
+          printf                                          "C:\\OTHERBIN\\winflexbison" >> %GITHUB_PATH%
+
+      # Choco Install meson
+      # BUT the "crazy-max/ghaction-chocolatey@v2" "install meson" msiexec.exe Exit code was '3010'.
+      - name: Install meson and add meson directory to the PATH for Compile using msvc and meson
+        if: ${{ env.os == 'windows-latest' && env.compilerClass == 'msvc' }}
+        shell: cmd
+        run: |
+          msiexec.exe /i meson-1.2.1-64.msi /qn /norestart /l*v meson.1.2.1.MsiInstall.log
+          printf "C:\Program Files\Meson" >> %GITHUB_PATH%
+          type meson.1.2.1.MsiInstall.log
+
+      # 34 seconds with zero packages
+      # 2 minutes and seven(7) seconds with everything
+      - name: Install Windows mingw Software
+        if: ${{ env.os == 'windows-latest' && env.compilerClass == 'MSYS2' }}
+        uses: msys2/setup-msys2@v2
+        with:
+          # By default, the installation is not updated; hence package versions are those of the installation tarball.
+          # Faster without the "update"
+          # update: true
+          update: true
+          # do not inherit anything from the PATH
+          path-type: strict
+          msystem: ${{ env.compilerEnv }}
+          #
+          install: >-
+            ${{ env.MINGW_PACKAGE_PREFIX }}-pkg-config
+            ${{ env.MINGW_PACKAGE_PREFIX }}-curl
+            git
+            ${{ env.MINGW_PACKAGE_PREFIX }}-meson
+            ${{ env.MINGW_PACKAGE_PREFIX }}-make
+            make
+            ${{ env.MINGW_PACKAGE_PREFIX }}-${{ env.compilerExe }}
+            tar
+            gzip
+            ${{ env.MINGW_PACKAGE_PREFIX }}-readline
+            ${{ env.MINGW_PACKAGE_PREFIX }}-zlib
+            ${{ env.MINGW_PACKAGE_PREFIX }}-icu
+            icu-devel
+            git
+            flex
+            bison
+            ${{ env.MINGW_PACKAGE_PREFIX }}-perl
+            ${{ env.MINGW_PACKAGE_PREFIX }}-winpty
+            p7zip
+            tar
+            zstd
+            ${{ env.MINGW_PACKAGE_PREFIX }}-tools-git
+            ${{ env.MINGW_PACKAGE_PREFIX }}-binutils
+            ${{ env.MINGW_PACKAGE_PREFIX }}-diffutils
+            ${{ env.MINGW_PACKAGE_PREFIX }}-libxml2
+            ${{ env.MINGW_PACKAGE_PREFIX }}-libxslt
+            ${{ env.MINGW_PACKAGE_PREFIX }}-lz4
+
+      - name: Install Windows mingw Software Repository PostgreSQL
+        if: ${{ env.os == 'windows-latest' && env.compilerClass == 'MSYS2' && env.buildpgFromSRC != 'true' }}
+        env:
+          # Msys OS variable
+          msystem: ${{ env.compilerEnv }}
+        run: |
+          echo "Install Windows mingw Software Repository PostgreSQL"
+          set -x -v -e
+          pacman -S --needed --noconfirm ${{ env.MINGW_PACKAGE_PREFIX }}-postgresql
+
+      - name: Set up Cygwin
+        if: ${{ env.os == 'windows-latest' && env.compilerClass == 'cygwin' }}
+        uses: cygwin/cygwin-install-action@v4
+        with:
+          # x86 or x86_64
+          #         GitHub offers ternary operator like behaviour that you can use in expressions
+          platform: ${{ env.Platform == 'x64' && 'x86_64' || 'x86' }}
+          # REQUIRED def true - otherwise the default install MING64 "bash" will be found
+          # add-to-path: true
+          packages: >-
+             cygrunsrv pkg-config  meson  gendef
+             gcc-core  make  tar  gzip  libreadline7  zlib  icu-devel  bison  perl
+             flex  libreadline-devel  libssl-devel  libxml2-devel  libxslt-devel  openldap-devel  zlib-devel
+             libintl-devel  libcrypt-devel
+             p7zip
+             postgresql-client  postgresql  postgresql-devel
+             libpq-devel
+             R  R-debuginfo
+
+      # If the PostgreSQL version is 16 or greater, I can compile PostgreSQL using meson.
+      - name: Compile PG using pgSRCversion and PG_SOURCE and Install to here PG_HOME
+        if: ${{ env.os == 'windows-latest' && ( env.compilerClass == 'MSYS2' || env.compilerClass == 'cygwin' ) && env.buildpgFromSRC == 'true' }}
+        env:
+          # Cygwin OS variables
+          SHELLOPTS: igncr
+          CHERE_INVOKING: 1
+          # Msys OS variable
+          msystem: ${{ env.compilerEnv }}
+          Configuration: ${{ env.Configuration }}
+          #
+          PG_SOURCE: ${{ env.PG_SOURCE }}
+          PG_HOME: ${{ env.PG_HOME }}
+          buildpgFromSRCmethod: ${{ env.buildpgFromSRCmethod }}
+        run: |
+          echo "Compile PG using pgSRCversion and PG_SOURCE and Install to here PG_HOME"
+          set -x -v -e
+          if [ "${OperatingSystem}" == "" ]; then export OperatingSystem=$(uname -o); fi
+          echo "OperatingSystem: ${OperatingSystem}"
+          if [ "${OperatingSystem}" == "Cygwin" ]
+          then
+            # because I set CHERE_INVOKING to be 1
+            export PATH=/usr/local/bin:/usr/bin:/usr/lib/lapack:/bin:/usr/sbin:/sbin
+          fi
+          uname -a
+          echo "compilerEnv: ${{ env.compilerEnv }}"
+          echo "bash: $(which bash)"
+          echo "Present Working Directory: $(pwd)"
+          #
+          if [ "${OperatingSystem}" == "Msys" ]
+          then
+            echo "msystem: ${msystem}"
+            export | grep MINGW
+            export | grep MSYSTEM
+          fi
+          #
+          echo "pgSRCversion: ${pgSRCversion}"
+          echo "PG_SOURCE:    ${PG_SOURCE}"
+          echo "PG_HOME:      ${PG_HOME}"
+
+          if [ "${PG_SOURCE}" == "notset" ] || [ "${PG_SOURCE}" == "" ]
+          then
+            echo "One must set PG_SOURCE=value"
+            exit 1
+          fi
+
+          export PG_SOURCE=$(cygpath "${PG_SOURCE}")
+          echo  "cygpath PG_SOURCE: ${PG_SOURCE}"
+
+          if [ ! -d "${PG_SOURCE}" ]
+          then
+            echo "Missing already-existing PG source code directory: ${PG_SOURCE}"
+            echo "Did you download the source code from Github?"
+            exit 1
+          fi
+
+          if [ "${PG_HOME}" == "notset" ] || [ "${PG_HOME}" == "" ]
+          then
+            echo "One must set PG_HOME=value"
+            exit 1
+          fi
+
+          export PG_HOME=$(cygpath "${PG_HOME}")
+          echo  "cygpath   PG_HOME: ${PG_HOME}"
+
+          if [ "${buildpgFromSRCmethod}" == "notset" ] || [ "${buildpgFromSRCmethod}" == "" ]
+          then
+            echo "One must set buildpgFromSRCmethod=value"
+            exit 1
+          fi
+
+          if [ "${buildpgFromSRCmethod}" == "make" ]
+          then
+            pushd "${PG_SOURCE}"
+
+            echo "BEGIN PostgreSQL make CONFIGURE"
+            set +x +v +e
+
+            if [ "${Configuration}" == "Debug" ]
+            then
+              ./configure --prefix="${PG_HOME}" --enable-depend --disable-rpath --without-icu --enable-debug --enable-cassert CFLAGS="-ggdb -Og -g3 -fno-omit-frame-pointer"
+            fi
+
+            if [ "${Configuration}" == "Release" ]
+            then
+              ./configure --prefix="${PG_HOME}" --enable-depend --disable-rpath --without-icu
+            fi
+
+            set -x -v -e
+            echo "END   PostgreSQL make CONFIGURE"
+
+            echo "BEGIN PostgreSQL make BUILD"
+            set +x +v +e
+            make
+            set -x -v -e
+            echo "END   PostgreSQL make BUILD"
+
+            echo "BEGIN PostgreSQL make INSTALL to ${PG_HOME}"
+            set +x +v +e
+            make install
+            set -x -v -e
+            echo "END   PostgreSQL make INSTALL to ${PG_HOME}"
+
+            popd # from "${PG_SOURCE}"
+          fi
+
+          if [ "${buildpgFromSRCmethod}" == "meson" ]
+          then
+            pushd "${PG_SOURCE}"
+
+            rm -Rf build
+
+            echo "BEGIN PostgreSQL meson CONFIGURE"
+            set +x +v +e
+
+            if [ "${Configuration}" == "Debug" ]
+            then
+              meson setup --prefix "${PG_HOME}"                                   -Db_pie=true -Dnls=disabled -Dplperl=disabled -Dplpython=disabled -Dpltcl=disabled -Dicu=disabled -Dllvm=disabled -Dlz4=disabled -Dzstd=disabled -Dgssapi=disabled -Dldap=disabled -Dpam=disabled -Dbsd_auth=disabled -Dsystemd=disabled -Dbonjour=disabled -Dlibxml=disabled -Dlibxslt=disabled -Dreadline=enabled -Dzlib=disabled -Ddocs=disabled -Ddocs_pdf=disabled -Dcassert=false -Dtap_tests=disabled -Db_coverage=false -Ddtrace=disabled build
+            fi
+
+            if [ "${Configuration}" == "Release" ]
+            then
+              meson setup --prefix "${PG_HOME}" -Dbuildtype=release -Ddebug=false -Db_pie=true -Dnls=disabled -Dplperl=disabled -Dplpython=disabled -Dpltcl=disabled -Dicu=disabled -Dllvm=disabled -Dlz4=disabled -Dzstd=disabled -Dgssapi=disabled -Dldap=disabled -Dpam=disabled -Dbsd_auth=disabled -Dsystemd=disabled -Dbonjour=disabled -Dlibxml=disabled -Dlibxslt=disabled -Dreadline=enabled -Dzlib=disabled -Ddocs=disabled -Ddocs_pdf=disabled -Dcassert=false -Dtap_tests=disabled -Db_coverage=false -Ddtrace=disabled build
+            fi
+
+            set -x -v -e
+            echo "END   PostgreSQL meson CONFIGURE"
+
+            echo "BEGIN PostgreSQL meson BUILD"
+            set +x +v +e
+            meson compile -C build -v
+            set -x -v -e
+            echo "END   PostgreSQL meson BUILD"
+
+            echo "BEGIN PostgreSQL meson INSTALL to ${PG_HOME}"
+            set +x +v +e
+            meson install -C build
+            set -x -v -e
+            echo "END   PostgreSQL meson INSTALL to ${PG_HOME}"
+
+            popd # from "${PG_SOURCE}"
+          fi
+
+          #
+          # For artifact naming, determine the Compiler Supplied pgversion.
+          #
+          export pgversion=$("${PG_HOME}/bin/pg_config" | grep "^VERSION" | sed "s/ = /=/" | sed "s/^.*=//" | grep -oP '[ ].*$' | grep -oP '\d.*$')
+          # potential override
+          echo "pgversion=${pgversion}" >> ${GITHUB_ENV}
+          echo "pg_config VERSION pgversion: ${pgversion}"
+
+          if [ -d "${PG_HOME}" ]
+          then
+            echo "BEGIN compressing pg artifact"
+            7z a -t7z -mmt24 -mx7 -r pg-artifact.7z  "${PG_HOME}/*"
+            echo "END   compressing pg artifact"
+          fi
+
+      - name: Windows Prep PG Artifact
+        if: ${{ env.os == 'windows-latest' && env.compilerClass == 'MSYS2' && env.buildpgFromSRC == 'true' }}
+        env:
+          PGVER2: ${{ env.PGVER2 }}
+          Platform: ${{ env.Platform }}
+        shell: cmd
+        run: |
+          echo on
+          if exist pg-artifact.7z copy pg-artifact.7z pg-${{ env.os }}-${{ env.compilerEnv }}-${{ env.Platform }}-PG${{ env.pgversion }}-${{ env.Configuration }}.7z
+          if exist pg-artifact.7z dir                 pg-${{ env.os }}-${{ env.compilerEnv }}-${{ env.Platform }}-PG${{ env.pgversion }}-${{ env.Configuration }}.7z
+
+      - name: Upload artifact PG for export for LOCAL testing
+        if: ${{ env.os == 'windows-latest' &&  env.compilerClass == 'MSYS2' && env.buildpgFromSRC == 'true' }}
+        uses: actions/upload-artifact@v3
+        with:
+          name: pg-${{ env.os }}-${{ env.compilerEnv }}-${{ env.Platform }}-PG${{ env.pgversion }}-${{ env.Configuration }}
+          path: |
+            pg-${{ env.os }}-${{ env.compilerEnv }}-${{ env.Platform }}-PG${{ env.pgversion }}-${{ env.Configuration }}.7z
+
+      - name: Windows non-msvc Meson PG and Meson PL/R Setup Compile and Meson Test
+        if: ${{ env.os == 'windows-latest' && ( env.compilerClass == 'MSYS2' || env.compilerClass == 'cygwin' ) && env.buildpgANDplrInSRCcontrib == 'true' }}
+        env:
+          # Cygwin shell variables
+          SHELLOPTS: igncr
+          CHERE_INVOKING: 1
+          # Msys shell variable
+          msystem: ${{ env.compilerEnv }}
+          Configuration: ${{ env.Configuration }}
+          #
+          R_HOME: ${{ env.R_HOME }}
+          Platform: ${{ env.Platform }}
+          R_ARCH: ${{ env.R_ARCH }}
+          rversion: ${{ env.rversion }}
+          PG_SOURCE: ${{ env.PG_SOURCE }} # different - full
+          PG_HOME: ${{ env.PG_HOME }}     # different - empty - and below - it is not used
+          PGROOT2: ${{ env.PGROOT2 }}
+        run: |
+          echo "Windows non-msvc Meson PG and Meson PL/R Setup Compile and Meson Test"
+          set -x -v -e
+          echo "Windows non-msvc Meson PL/R Setup Compile and Non-Meson Manual Test"
+          set -x -v -e
+          if [ "${OperatingSystem}" == "" ]; then export OperatingSystem=$(uname -o); fi
+          echo "OperatingSystem: ${OperatingSystem}"
+          if [ "${OperatingSystem}" == "Cygwin" ]
+          then
+            # because I set CHERE_INVOKING to be 1
+            export PATH=/usr/local/bin:/usr/bin:/usr/lib/lapack:/bin:/usr/sbin:/sbin
+          fi
+          uname -a
+          echo "compilerEnv: ${{ env.compilerEnv }}"
+          echo "bash: $(which bash)"
+          echo "Present Working Directory: $(pwd)"
+          #
+          if [ "${OperatingSystem}" == "Msys" ]
+          then
+            echo "msystem: ${msystem}"
+            export | grep MINGW
+            export | grep MSYSTEM
+          fi
+          #
+          echo "R_HOME: ${R_HOME}"
+          echo "Platform: ${Platform}"
+          echo "R_ARCH: ${R_ARCH}"
+          echo "rversion: ${rversion}"
+          echo "PG_SOURCE: ${PG_SOURCE}"
+          echo "PG_HOME: ${PG_HOME}"
+          echo "PGROOT2: ${PGROOT2}"
+
+          export WORKSPACE=$(pwd)
+          echo "WORKSPACE ${WORKSPACE}"
+
+          #### BEGIN R SECTION ####
+
+          #
+          # Trying smartly and hard to find the R_HOME
+          #
+          if [ ! "${R_HOME}" == "notset" ] && [ ! "${R_HOME}" == "" ]
+          then
+            export R_HOME=$(cygpath "${R_HOME}")
+
+            # user supplied variable
+            echo "cygpath R_HOME: ${R_HOME}"
+
+            # PATHs are needed for the proper compile and runtime
+            # find "libraries"
+            # R Non-Sub-Architectures
+            export PATH="${R_HOME}/bin:${PATH}"
+
+          fi
+
+          export ERRORLEVEL=0
+          which R || export ERRORLEVEL=$?
+          if [ ! "${ERRORLEVEL}" == "0" ]; then echo ERROR - No R found in the PATH - ${PATH}; exit 1;fi
+
+          if [ "${R_HOME}" == "notset" ] || [ "${R_HOME}" == "" ]
+          then
+            # I CAN NOT FIGURE OUT HOW TO extract the R_HOME into an
+            # Environment Variable on Github Actions
+            #
+            # THIS DOES NOT EXTRACT
+            # Rscript . . . cat(Sys.getenv("R_HOME"))
+
+            # Temporary workarounds
+
+            if [ "${OperatingSystem}" == "Cygwin" ]
+            then
+              # dangerously assumes that
+              # 1. R is installed and 2. R is installed in the DEFAULT location
+              export R_HOME=/usr/lib/R
+              echo "Cygwin assume R_HOME: ${R_HOME}"
+              echo "R_HOME=$(cygpath -w ${R_HOME})" >> ${GITHUB_ENV}
+            fi
+
+            # R for Windows SUFFICIENT
+            if [ "${OperatingSystem}" == "Msys" ]
+            then
+              # ONLY "R for Windows"
+              # dangerously assumes that
+              # 1. R is installed and 2. R is in the PATH
+              export R_HOME=$(dirname $(dirname "$(which R)"))
+              # determined variable
+              echo "dirname which R R_HOME: ${R_HOME}"
+              echo "R_HOME=$(cygpath -w ${R_HOME})" >> ${GITHUB_ENV}
+            fi
+
+            # PATHs are needed for the proper compile and runtime
+            # find "libraries"
+            # R Non-Sub-Architectures
+            export PATH="${R_HOME}/bin:${PATH}"
+          fi
+
+          # Pipes have been known to fail in Msys
+          # when piping from a non-Msys program. E.g "R for Windows".
+          #
+          if [ ! "${OperatingSystem}" == "Msys" ]
+          then
+            # determine rversion xor verify user supplied rversion
+            #
+            # For artifact naming, match and verify the Compiler Supplied rversion.
+            #
+            export rversion_supplied=${rversion}
+            echo "rversion_supplied: ${rversion_supplied}"
+            if [ "${rversion_supplied}" == "notset" ] || [  "${rversion_supplied}" == "" ]
+            then
+              # For artifact naming, determine the Compiler Supplied rversion.
+              #
+              # OLD_R_HOME part - OperatingSystem "Cygwin"
+              #
+              export OLD_R_HOME=${R_HOME}
+              unset               R_HOME
+              export  rversion=$(Rscript --version | grep -oP "\d+[.]\d+[.]\d+")
+              echo   "rversion: ${rversion}"
+              echo   "rversion=${rversion}" >> ${GITHUB_ENV}
+              echo   "R --version: ${rversion}"
+              export R_HOME=${OLD_R_HOME}
+              unset OLD_R_HOME
+            fi
+            # Fail if the user supplied rversion does not match the true rversion
+            #
+            if [ ! "${rversion_supplied}" == "notset" ] && [ ! "${rversion_supplied}" == "" ]
+            then
+              if [ ! "${rversion_supplied}" == "${rversion}" ]
+              then
+                echo "WARNING rversion_supplied ${rversion_supplied} != rversion ${rversion}"
+              fi
+            fi
+          fi
+          if [ "${rversion}" == "notset" ] || [ "${rversion}" == "" ]
+          then
+            echo ERROR - No user supplied rversion and no determined rversion - ${rversion}
+            exit 1
+          fi
+
+          #
+          # verify user supplied R_ARCH or determine the R_ARCH
+          #
+          if [ ! "${R_ARCH}" == "notset" ] && [ ! "${R_ARCH}" == "" ]
+          then
+            if [ ! -d "${R_HOME}/bin${R_ARCH}" ]
+            then
+               echo ERROR - No user supplied R_ARCH found in - ${R_HOME}/bin${R_ARCH}
+               exit 1
+            fi
+          fi
+
+          # Note on Windows, one can compile /i386 on x64.
+          # But that scenario is too complex to support that here.
+          #
+          if [  "${R_ARCH}" == "notset" ] || [ "${R_ARCH}" == "" ]
+          then
+            if [ "${Platform}" == "x64" ] && [ -d "${R_HOME}/bin/x64" ]
+            then
+              export R_ARCH="/x64"
+              echo "user and determined R_ARCH: ${R_ARCH}"
+            fi
+            if [ "${Platform}" == "x86" ] && [ -d "${R_HOME}/bin/i386" ]
+            then
+              export R_ARCH="/i386"
+              echo "user and determined R_ARCH: ${R_ARCH}"
+            fi
+            #
+            # FUTURE - The ONE(first) subdirectory name in alphabetical order
+            # is in a space separated string.
+            # pushd "${R_HOME}/bin"; ls -d */ | grep -oP '^.*[^/]' | xargs; popd
+          fi
+
+          if [  "${R_ARCH}" == "notset" ] || [   "${R_ARCH}" == "" ]
+          then
+            unset R_ARCH
+            echo "The rest of this program uses R_ARCH like this: R_ARCH: ${R_ARCH}"
+          fi
+
+          # LAST
+          if [ ! "${R_ARCH}" == "notset" ] && [ ! "${R_ARCH}" == "" ]
+          then
+            echo "R_ARCH=${R_ARCH}" >> ${GITHUB_ENV}
+            echo "The rest of this program uses R_ARCH like this: R_ARCH: ${R_ARCH}"
+            # R    Sub-Architectures
+            export PATH="${R_HOME}/bin${R_ARCH}:${PATH}"
+          fi
+
+          #### END R SECTION ####
+
+          #### BEGIN PG_SOURCE AND PG_HOME SECTION ####
+
+          if [ ! "${PG_SOURCE}" == "notset" ] && [ ! "${PG_SOURCE}" == "" ]
+          then
+            export PG_SOURCE=$(cygpath "${PG_SOURCE}")
+            echo "cygpath PG_SOURCE: ${PG_SOURCE}"
+          fi
+
+          if [ ! "${PG_HOME}" == "notset" ] && [ ! "${PG_HOME}" == "" ]
+          then
+            export PG_HOME=$(cygpath "${PG_HOME}")
+            echo "cygpath PG_HOME: ${PG_HOME}"
+          fi
+
+          #### END PG_SOURCE AND PG_HOME SECTION ####
+
+          #### BEGIN PKGCONFIG SECTION ####
+
+          echo "PKG_CONFIG_PATH: ${PKG_CONFIG_PATH}"
+          echo "PKG_CONFIG_SYSTEM_INCLUDE_PATH: ${PKG_CONFIG_SYSTEM_INCLUDE_PATH}"
+          echo "PKG_CONFIG_SYSTEM_LIBRARY_PATH: ${PKG_CONFIG_SYSTEM_LIBRARY_PATH}"
+
+          # note "Cygwin" has "no defaults"
+          #
+          # note MSYS(mingw) UCRT uses MSYSTEM_PREFIX="/ucrt64" in place of "/usr"
+          # note MSYS(mingw) UCRT variable PKG_CONFIG_PATH at the tail also has "/ucrt64/share/pkgconfig"
+          #
+          # This case handles Cygwin.
+          if [ "${PKG_CONFIG_PATH}" == "" ];                then export PKG_CONFIG_PATH="/usr/lib/pkgconfig"; fi
+          if [ "${PKG_CONFIG_SYSTEM_INCLUDE_PATH}" == "" ]; then export PKG_CONFIG_SYSTEM_INCLUDE_PATH="/usr/include"; fi
+          if [ "${PKG_CONFIG_SYSTEM_LIBRARY_PATH}" == "" ]; then export PKG_CONFIG_SYSTEM_LIBRARY_PATH="/usr/lib"; fi
+
+          export PKG_CONFIG_PATH_ORIG=$(echo "${PKG_CONFIG_PATH}" |  grep -o '^[^:]*')
+          echo "PKG_CONFIG_PATH_ORIG: ${PKG_CONFIG_PATH}"
+
+          export PKG_CONFIG_SYSTEM_INCLUDE_PATH_ORIG=$(echo "${PKG_CONFIG_SYSTEM_INCLUDE_PATH}" |  grep -o '^[^:]*')
+          echo "PKG_CONFIG_SYSTEM_INCLUDE_PATH_ORIG: ${PKG_CONFIG_SYSTEM_INCLUDE_PATH_ORIG}"
+
+          # For MSYS(mingw) and R environment variable R_ARCH and Rlib.dll.a.
+          # Need ONE single leftmost headish important library path.
+          export PKG_CONFIG_SYSTEM_LIBRARY_PATH_ORIG=$(echo "${PKG_CONFIG_SYSTEM_LIBRARY_PATH}" |  grep -o '^[^:]*')
+          # MSYS2(mingw) environments
+          # e.g. UCRT
+          # export PKG_CONFIG_SYSTEM_LIBRARY_PATH_ORIG="/ucrt64/lib"
+          echo "PKG_CONFIG_SYSTEM_LIBRARY_PATH_ORIG: ${PKG_CONFIG_SYSTEM_LIBRARY_PATH_ORIG}"
+
+          echo "PKG_CONFIG_PATH: ${PKG_CONFIG_PATH}"
+          echo "PKG_CONFIG_SYSTEM_INCLUDE_PATH: ${PKG_CONFIG_SYSTEM_INCLUDE_PATH}"
+          echo "PKG_CONFIG_SYSTEM_LIBRARY_PATH: ${PKG_CONFIG_SYSTEM_LIBRARY_PATH}"
+
+          #### END PKGCONFIG SECTION ####
+
+          #### BEGIN MAKE R INTO A LIBRARY ####
+
+          # Make R into a library
+          if [ ! -d "${PKG_CONFIG_SYSTEM_LIBRARY_PATH_ORIG}/pkgconfig" ]
+          then
+            mkdir "${PKG_CONFIG_SYSTEM_LIBRARY_PATH_ORIG}/pkgconfig"
+          fi
+
+          if [ ! -f "${PKG_CONFIG_SYSTEM_LIBRARY_PATH_ORIG}/pkgconfig/libR.pc" ]
+          then
+            # Uses the provided template file "libR.pc"
+            # This template file is "based" off of the "R for Cygwin" file /lib/pkgconfig/libR.pc.
+            cat "libR.pc" | sed "s|R_HOME|${R_HOME}|" | sed "s|R_ARCH|${R_ARCH}|" | sed "s/rversion/${rversion}/" > "${PKG_CONFIG_SYSTEM_LIBRARY_PATH_ORIG}/pkgconfig/libR.pc"
+          fi
+
+          # Cygwin already has the file /usr/lib/R/lib/libR.dll.a
+          # MSYS2 (mingw) compilers require libR.dll.a.
+          # That file is created by ddltool program parameter "--output-lib".
+          #
+          # Note, Windows compilers (e.g. msvc) require R.lib.
+          # To create this file, instead of using the "dlltool" program, use the msvc "lib" program.
+          # Alternately, in the Windows "msvc" compiler case, just rename an archive dll.a to be a .lib,
+          # and that also works.
+          #
+          if [ ! -d "${PKG_CONFIG_SYSTEM_LIBRARY_PATH_ORIG}${R_ARCH}" ]
+          then
+            mkdir   "${PKG_CONFIG_SYSTEM_LIBRARY_PATH_ORIG}${R_ARCH}"
+          fi
+
+          # Create and Move, or, Copy, the R static library,
+          # to the target location - "${PKG_CONFIG_SYSTEM_LIBRARY_PATH_ORIG}${R_ARCH}/libR.dll.a"
+          if [ ! -f "${PKG_CONFIG_SYSTEM_LIBRARY_PATH_ORIG}${R_ARCH}/libR.dll.a" ]
+          then
+            #
+            # These should? be exclusive cases.
+            #
+            # Cygwin Repository R install case.
+            # Do I need to do this at all?
+            # If I am not given the R.dll, then THEY must provide the static library libR.dll.a.
+            if [ -f         "${PKG_CONFIG_SYSTEM_LIBRARY_PATH_ORIG}/R/lib/libR.dll.a" ]
+            then
+              pushd         "${PKG_CONFIG_SYSTEM_LIBRARY_PATH_ORIG}/R/lib"
+              cp libR.dll.a "${PKG_CONFIG_SYSTEM_LIBRARY_PATH_ORIG}${R_ARCH}/libR.dll.a"
+              popd # from   "${PKG_CONFIG_SYSTEM_LIBRARY_PATH_ORIG}/R/lib"
+            fi
+            # Msys case using "R for Windows" from CRAN
+            # If I am given the R.dll, then I can myself, create the static library libR.dll.a.
+            if [ -f "${R_HOME}/bin${R_ARCH}/R.dll" ]
+            then
+              pushd "${R_HOME}/bin${R_ARCH}"
+              gendef  -         R.dll >     R.def
+              dlltool --dllname R.dll --def R.def --output-lib libR.dll.a
+              #
+              # Put libR.dll.a into the general library location {...ORIG}${R_ARCH}/libR.dll.a
+              mv libR.dll.a "${PKG_CONFIG_SYSTEM_LIBRARY_PATH_ORIG}${R_ARCH}/libR.dll.a"
+              popd # from "${R_HOME}/bin${R_ARCH}"
+            fi
+          fi
+
+          #### END MAKE R INTO A LIBRARY ####
+
+          #### BEGIN SETUP MESON.BUILD FILES AND OPTIONS ####
+
+          cat _meson_options.txt_postgres_root_additional_plr_option.txt >>         ${PG_SOURCE}/meson_options.txt
+          echo 'subdir('"'"'plr'"'"')'                                   >> ${PG_SOURCE}/contrib/meson.build
+
+          ######## mv  meson.build meson.build.STANDALONE.HIDDEN
+          ######## mv _meson.build meson.build
+
+          #### END SETUP MESON.BUILD FILES AND OPTIONS ####
+
+          #### BEGIN CREATE THE PLR DIRECTORY ####
+
+          # Create the contrib/plr directory parallel in contrib.
+          # Copy all of the PL/R source code into contrib/plr.
+          #
+          mkdir     "${PG_SOURCE}/contrib/plr"
+          cp -R   * "${PG_SOURCE}/contrib/plr"
+
+          #### END CREATE THE PLR DIRECTORY ####
+
+          #### BEGIN BUILD PG AND PLR AND TEST PLR ####
+
+          # from WORKSPACE
+          pushd "${PG_SOURCE}"
+
+          if [ "${Configuration}" == "Debug" ]
+          then
+            meson setup --prefix "${PG_HOME}"                                   -Db_pie=true -DR_HOME=${R_HOME} -Dnls=disabled -Dplperl=disabled -Dplpython=disabled -Dpltcl=disabled -Dicu=disabled -Dllvm=disabled -Dlz4=disabled -Dzstd=disabled -Dgssapi=disabled -Dldap=disabled -Dpam=disabled -Dbsd_auth=disabled -Dsystemd=disabled -Dbonjour=disabled -Dlibxml=disabled -Dlibxslt=disabled -Dreadline=enabled -Dzlib=disabled -Ddocs=disabled -Ddocs_pdf=disabled -Dcassert=false -Dtap_tests=disabled -Db_coverage=false -Ddtrace=disabled build
+          fi
+
+          if [ "${Configuration}" == "Release" ]
+          then
+            meson setup --prefix "${PG_HOME}" -Dbuildtype=release -Ddebug=false -Db_pie=true -DR_HOME=${R_HOME} -Dnls=disabled -Dplperl=disabled -Dplpython=disabled -Dpltcl=disabled -Dicu=disabled -Dllvm=disabled -Dlz4=disabled -Dzstd=disabled -Dgssapi=disabled -Dldap=disabled -Dpam=disabled -Dbsd_auth=disabled -Dsystemd=disabled -Dbonjour=disabled -Dlibxml=disabled -Dlibxslt=disabled -Dreadline=enabled -Dzlib=disabled -Ddocs=disabled -Ddocs_pdf=disabled -Dcassert=false -Dtap_tests=disabled -Db_coverage=false -Ddtrace=disabled build
+          fi
+
+          meson compile -C build -v
+
+          export pgversion=$("${PG_SOURCE}/build/src/bin/pg_config/pg_config" | grep "^VERSION" | sed "s/ = /=/" | sed "s/^.*=//" | grep -oP '[ ].*$' | grep -oP '\d.*$')
+          # potential override
+          echo "pgversion=${pgversion}" >> ${GITHUB_ENV}
+          echo "pg_config VERSION pgversion: ${pgversion}"
+
+          if [ "${OperatingSystem}" == "Cygwin" ]
+          then
+            echo "cygrunsrv START"
+            # shutdown current
+            #### cygrunsrv -E cygserver || true
+            # uninstall previous
+            #### cygrunsrv -R cygserver || true
+            # install
+            cygserver-config --yes
+            # postgresql failing with below error on lion os x
+            # https://stackoverflow.com/questions/6861945/postgresql-failing-with-below-error-on-lion-os-x#:~:text=Failed%20system%20call%20was%20shmget,the%20kernel%20with%20larger%20SHMMAX.
+            echo kern.ipc.shmall 4096 >>     /etc/defaults/etc/cygserver.conf
+            echo kern.ipc.shmmax 16777216 >> /etc/defaults/etc/cygserver.conf
+
+            # start
+            cygrunsrv -S cygserver
+          fi
+
+          # meson has no "test" pre-req system.  So this "ordered" implentation is a kind of "hack".
+          # sometimes the "plr" regression test fails if an "easier" regression test did not come before it.
+          meson test -C build --num-processes 1 -v --suite setup --suite cube
+
+          meson test -C build --num-processes 1 -v --suite setup --suite plr
+
+          if [ "${OperatingSystem}" == "Cygwin" ]
+          then
+            echo "cygrunsrv STOP"
+            # shutdown current
+            cygrunsrv -E cygserver
+            # uninstall previous
+            #### cygrunsrv -R cygserver
+          fi
+
+          popd # from "${PG_SOURCE}"
+          # back in WORKSPACE
+
+          #### END BUILD PG AND PLR AND TEST PLR ####
+
+          # save GOOD artifact plr.dll
+          #
+          if [ -f "${PG_SOURCE}/build/contrib/plr/plr.dll" ]
+          then
+            echo "Save plr.dll to be an artifact."
+            mkdir -p                                             ${WORKSPACE}/tmp/lib
+            cp    LICENSE                                        ${WORKSPACE}/tmp/PLR_LICENSE
+            cp    "${PG_SOURCE}/build/contrib/plr/plr.dll"       ${WORKSPACE}/tmp/lib
+            ls -alrt                                             ${WORKSPACE}/tmp/lib/plr.dll
+            mkdir -p                                             ${WORKSPACE}/tmp/share/extension
+            cp    *.control                                      ${WORKSPACE}/tmp/share/extension
+            cp    *.sql                                          ${WORKSPACE}/tmp/share/extension
+          fi
+
+          #
+          # save GOOD artifact plr.dll.a
+          #
+          if [ -f "${PG_SOURCE}/build/contrib/plr/plr.dll.a" ]
+          then
+            echo "Save plr.dll.a to be an artifact."
+            mkdir -p                                               ${WORKSPACE}/tmp/lib
+            cp    "${PG_SOURCE}/build/contrib/plr/plr.dll.a"       ${WORKSPACE}/tmp/lib
+            ls -alrt                                               ${WORKSPACE}/tmp/lib/plr.dll.a
+          fi
+
+          # 7z GOOD PL/R Artifact for LATER Release
+          echo "7z: $(which 7z)"
+          echo 7z a -r ${WORKSPACE}/plr-artifact.zip  ${WORKSPACE}/tmp/*
+          if [ -f "${WORKSPACE}/tmp/PLR_LICENSE" ]
+          then
+            echo "Create PL/R Artifact .zip for future Release"
+            7z a -r ${WORKSPACE}/plr-artifact.zip  ${WORKSPACE}/tmp/*
+          fi
+
+          # if "PostgreSQL for Windows" exists, then
+          # copy "Msys artifacts into "PostgreSQL for Windows" for future testing if env.MSYS2testonpgWIN == 'true'.
+          #
+          if ( [ ! "${PGROOT2}" == "notset" ] && [ ! "${PGROOT2}" == "" ] ) && [ "${OperatingSystem}" == "Msys" ]
+          then
+            export PGROOT2=$(cygpath "${PGROOT2}")
+            echo  "cygpath PGROOT2: ${PGROOT2}"
+
+            if [ -d "${PGROOT2}" ]
+            then
+              if [ -f "${PG_SOURCE}/build/contrib/plr/plr.dll" ]
+              then
+                echo "PGROOT2 is found. Preparing PostgreSQL for Windows testing."
+
+                cp  "${PG_SOURCE}/build/contrib/plr/plr.dll"   "${PGROOT2}/lib"
+                ls -alrt                                       "${PGROOT2}/lib/plr.dll"
+                cp plr.control                                 "${PGROOT2}/share/extension"
+                ls -alrt                                       "${PGROOT2}/share/extension/plr.control"
+                cp plr--*.sql                                  "${PGROOT2}/share/extension"
+                ls -alrt                                       "${PGROOT2}"/share/extension/plr--*.sql
+
+              fi
+            fi
+          fi
+
+      - name: Windows non-msvc Meson PL/R Setup Compile and Non-Meson Manual Test
+        if: ${{ env.os == 'windows-latest' && ( env.compilerClass == 'MSYS2' || env.compilerClass == 'cygwin' ) && env.buildpgANDplrInSRCcontrib != 'true' }}
+        env:
+          # Cygwin shell variables
+          SHELLOPTS: igncr
+          CHERE_INVOKING: 1
+          # Msys shell variable
+          msystem: ${{ env.compilerEnv }}
+          Configuration: ${{ env.Configuration }}
+          #
+          R_HOME: ${{ env.R_HOME }}
+          Platform: ${{ env.Platform }}
+          R_ARCH: ${{ env.R_ARCH }}
+          rversion: ${{ env.rversion }}
+          PG_HOME: ${{ env.PG_HOME }} # different
+          PGROOT2: ${{ env.PGROOT2 }}
+        run: |
+          echo "Windows non-msvc Meson PL/R Setup Compile and Non-Meson Manual Test"
+          set -x -v -e
+          if [ "${OperatingSystem}" == "" ]; then export OperatingSystem=$(uname -o); fi
+          echo "OperatingSystem: ${OperatingSystem}"
+          if [ "${OperatingSystem}" == "Cygwin" ]
+          then
+            # because I set CHERE_INVOKING to be 1
+            export PATH=/usr/local/bin:/usr/bin:/usr/lib/lapack:/bin:/usr/sbin:/sbin
+          fi
+          uname -a
+          echo "compilerEnv: ${{ env.compilerEnv }}"
+          echo "bash: $(which bash)"
+          echo "Present Working Directory: $(pwd)"
+          #
+          if [ "${OperatingSystem}" == "Msys" ]
+          then
+            echo "msystem: ${msystem}"
+            export | grep MINGW
+            export | grep MSYSTEM
+          fi
+          #
+          echo "R_HOME: ${R_HOME}"
+          echo "Platform: ${Platform}"
+          echo "R_ARCH: ${R_ARCH}"
+          echo "rversion: ${rversion}"
+          echo "PG_HOME: ${PG_HOME}"
+          echo "PGROOT2: ${PGROOT2}"
+
+          export WORKSPACE=$(pwd)
+          echo "WORKSPACE ${WORKSPACE}"
+
+          #### BEGIN R SECTION ####
+
+          #
+          # Trying smartly and hard to find the R_HOME
+          #
+          if [ ! "${R_HOME}" == "notset" ] && [ ! "${R_HOME}" == "" ]
+          then
+            export R_HOME=$(cygpath "${R_HOME}")
+
+            # user supplied variable
+            echo "cygpath R_HOME: ${R_HOME}"
+
+            # PATHs are needed for the proper compile and runtime
+            # find "libraries"
+            # R Non-Sub-Architectures
+            export PATH="${R_HOME}/bin:${PATH}"
+
+          fi
+
+          export ERRORLEVEL=0
+          which R || export ERRORLEVEL=$?
+          if [ ! "${ERRORLEVEL}" == "0" ]; then echo ERROR - No R found in the PATH - ${PATH}; exit 1;fi
+
+          if [ "${R_HOME}" == "notset" ] || [ "${R_HOME}" == "" ]
+          then
+            # I CAN NOT FIGURE OUT HOW TO extract the R_HOME into an
+            # Environment Variable on Github Actions
+            #
+            # THIS DOES NOT EXTRACT
+            # Rscript . . . cat(Sys.getenv("R_HOME"))
+
+            # Temporary workarounds
+
+            if [ "${OperatingSystem}" == "Cygwin" ]
+            then
+              # dangerously assumes that
+              # 1. R is installed and 2. R is installed in the DEFAULT location
+              export R_HOME=/usr/lib/R
+              echo "Cygwin assume R_HOME: ${R_HOME}"
+              echo "R_HOME=$(cygpath -w ${R_HOME})" >> ${GITHUB_ENV}
+            fi
+
+            # R for Windows SUFFICIENT
+            if [ "${OperatingSystem}" == "Msys" ]
+            then
+              # ONLY "R for Windows"
+              # dangerously assumes that
+              # 1. R is installed and 2. R is in the PATH
+              export R_HOME=$(dirname $(dirname "$(which R)"))
+              # determined variable
+              echo "dirname which R R_HOME: ${R_HOME}"
+              echo "R_HOME=$(cygpath -w ${R_HOME})" >> ${GITHUB_ENV}
+            fi
+
+            # PATHs are needed for the proper compile and runtime
+            # find "libraries"
+            # R Non-Sub-Architectures
+            export PATH="${R_HOME}/bin:${PATH}"
+          fi
+
+          # Pipes have been known to fail in Msys
+          # when piping from a non-Msys program. E.g "R for Windows".
+          #
+          if [ ! "${OperatingSystem}" == "Msys" ]
+          then
+            # determine rversion xor verify user supplied rversion
+            #
+            # For artifact naming, match and verify the Compiler Supplied rversion.
+            #
+            export rversion_supplied=${rversion}
+            echo "rversion_supplied: ${rversion_supplied}"
+            if [ "${rversion_supplied}" == "notset" ] || [  "${rversion_supplied}" == "" ]
+            then
+              # For artifact naming, determine the Compiler Supplied rversion.
+              #
+              # OLD_R_HOME part - OperatingSystem "Cygwin"
+              #
+              export OLD_R_HOME=${R_HOME}
+              unset               R_HOME
+              export  rversion=$(Rscript --version | grep -oP "\d+[.]\d+[.]\d+")
+              echo   "rversion: ${rversion}"
+              echo   "rversion=${rversion}" >> ${GITHUB_ENV}
+              echo   "R --version: ${rversion}"
+              export R_HOME=${OLD_R_HOME}
+              unset OLD_R_HOME
+            fi
+            # Fail if the user supplied rversion does not match the true rversion
+            #
+            if [ ! "${rversion_supplied}" == "notset" ] && [ ! "${rversion_supplied}" == "" ]
+            then
+              if [ ! "${rversion_supplied}" == "${rversion}" ]
+              then
+                echo "WARNING rversion_supplied ${rversion_supplied} != rversion ${rversion}"
+              fi
+            fi
+          fi
+          if [ "${rversion}" == "notset" ] || [ "${rversion}" == "" ]
+          then
+            echo ERROR - No user supplied rversion and no determined rversion - ${rversion}
+            exit 1
+          fi
+
+          #
+          # verify user supplied R_ARCH or determine the R_ARCH
+          #
+          if [ ! "${R_ARCH}" == "notset" ] && [ ! "${R_ARCH}" == "" ]
+          then
+            if [ ! -d "${R_HOME}/bin${R_ARCH}" ]
+            then
+               echo ERROR - No user supplied R_ARCH found in - ${R_HOME}/bin${R_ARCH}
+               exit 1
+            fi
+          fi
+
+          # Note on Windows, one can compile /i386 on x64.
+          # But that scenario is too complex to support that here.
+          #
+          if [  "${R_ARCH}" == "notset" ] || [ "${R_ARCH}" == "" ]
+          then
+            if [ "${Platform}" == "x64" ] && [ -d "${R_HOME}/bin/x64" ]
+            then
+              export R_ARCH="/x64"
+              echo "user and determined R_ARCH: ${R_ARCH}"
+            fi
+            if [ "${Platform}" == "x86" ] && [ -d "${R_HOME}/bin/i386" ]
+            then
+              export R_ARCH="/i386"
+              echo "user and determined R_ARCH: ${R_ARCH}"
+            fi
+            #
+            # FUTURE - The ONE(first) subdirectory name in alphabetical order
+            # is in a space separated string.
+            # pushd "${R_HOME}/bin"; ls -d */ | grep -oP '^.*[^/]' | xargs; popd
+          fi
+
+          if [  "${R_ARCH}" == "notset" ] || [   "${R_ARCH}" == "" ]
+          then
+            unset R_ARCH
+            echo "The rest of this program uses R_ARCH like this: R_ARCH: ${R_ARCH}"
+          fi
+
+          # LAST
+          if [ ! "${R_ARCH}" == "notset" ] && [ ! "${R_ARCH}" == "" ]
+          then
+            echo "R_ARCH=${R_ARCH}" >> ${GITHUB_ENV}
+            echo "The rest of this program uses R_ARCH like this: R_ARCH: ${R_ARCH}"
+            # R    Sub-Architectures
+            export PATH="${R_HOME}/bin${R_ARCH}:${PATH}"
+          fi
+
+          #### END R SECTION ####
+
+          #### BEGIN PG_HOME SECTION ####
+
+          #
+          # Trying smartly and hard to find the PG_HOME
+          #
+          if [ ! "${PG_HOME}" == "notset" ] && [ ! "${PG_HOME}" == "" ]
+          then
+            export PG_HOME=$(cygpath "${PG_HOME}")
+
+            # determined variable
+            echo "cygpath PG_HOME: ${PG_HOME}"
+
+            export ERRORLEVEL=0
+            ls -alrt "${PG_HOME}/bin/pg_config" || export ERRORLEVEL=$?
+            if [ ! "${ERRORLEVEL}" == "0" ]; then echo ERROR - No pg_config found at "${PG_HOME}/bin/pg_config"; exit 1;fi
+
+            # can find PG "libraries"
+            export PATH="${PG_HOME}/lib:${PATH}"
+            #
+            # can find PG "libraries" (and the CORRECT pg_config is found)
+            export PATH="${PG_HOME}/bin:${PATH}"
+
+          fi
+
+          export ERRORLEVEL=0
+          which pg_config || export ERRORLEVEL=$?
+
+          if [ ! "${ERRORLEVEL}" == "0" ]; then echo ERROR - No pg_config found in the PATH - ${PATH}; exit 1;fi
+
+          # had been already on the PATH
+          export BINDIR=$(pg_config | grep "^BINDIR" | sed "s/ = /=/" | sed "s/^.*=//")
+          export BINDIR=$(cygpath $(cygpath -wl "${BINDIR}"))
+
+          echo "pg_config BINDIR: ${BINDIR}"
+
+          if [ "${PG_HOME}" == "notset" ] || [ "${PG_HOME}" == "" ]
+          then
+            export PG_HOME=$(dirname "${BINDIR}")
+            echo "determined PG_HOME: ${PG_HOME}"
+            echo "PG_HOME=$(cygpath -w ${PG_HOME})" >> $GITHUB_ENV}
+
+            # found variable
+            echo "pg_config PG_HOME: ${PG_HOME}"
+
+            # can find PG "libraries"
+            export PATH="${PG_HOME}/lib:${PATH}"
+            #
+            # can find PG "libraries" (and the CORRECT pg_config is found)
+            export PATH="${PG_HOME}/bin:${PATH}"
+          fi
+
+          #
+          # For artifact naming, determine the Compiler Supplied pgversion.
+          #
+          export pgversion=$(pg_config | grep "^VERSION" | sed "s/ = /=/" | sed "s/^.*=//" | grep -oP '[ ].*$' | grep -oP '\d.*$')
+          # potential override
+          echo "pgversion=${pgversion}" >> ${GITHUB_ENV}
+          echo "pg_config VERSION pgversion: ${pgversion}"
+
+          export PKGLIBDIR=$(pg_config | grep "^PKGLIBDIR" | sed "s/ = /=/" | sed "s/^.*=//")
+          export PKGLIBDIR=$(cygpath $(cygpath -wl "${PKGLIBDIR}"))
+
+          echo "pg_config PKGLIBDIR: ${PKGLIBDIR}"
+
+          export SHAREDIR=$(pg_config | grep "^SHAREDIR" | sed "s/ = /=/" | sed "s/^.*=//")
+          export SHAREDIR=$(cygpath $(cygpath -wl "${SHAREDIR}"))
+
+          echo "pg_config SHAREDIR: ${SHAREDIR}"
+
+          #### END PG_HOME SECTION ####
+
+          #### BEGIN PKGCONFIG SECTION ####
+
+          echo "PKG_CONFIG_PATH: ${PKG_CONFIG_PATH}"
+          echo "PKG_CONFIG_SYSTEM_INCLUDE_PATH: ${PKG_CONFIG_SYSTEM_INCLUDE_PATH}"
+          echo "PKG_CONFIG_SYSTEM_LIBRARY_PATH: ${PKG_CONFIG_SYSTEM_LIBRARY_PATH}"
+
+          # note "Cygwin" has "no defaults"
+          #
+          # note MSYS(mingw) UCRT uses MSYSTEM_PREFIX="/ucrt64" in place of "/usr"
+          # note MSYS(mingw) UCRT variable PKG_CONFIG_PATH at the tail also has "/ucrt64/share/pkgconfig"
+          #
+          # This case handles Cygwin.
+          if [ "${PKG_CONFIG_PATH}" == "" ];                then export PKG_CONFIG_PATH="/usr/lib/pkgconfig"; fi
+          if [ "${PKG_CONFIG_SYSTEM_INCLUDE_PATH}" == "" ]; then export PKG_CONFIG_SYSTEM_INCLUDE_PATH="/usr/include"; fi
+          if [ "${PKG_CONFIG_SYSTEM_LIBRARY_PATH}" == "" ]; then export PKG_CONFIG_SYSTEM_LIBRARY_PATH="/usr/lib"; fi
+
+          export PKG_CONFIG_PATH_ORIG=$(echo "${PKG_CONFIG_PATH}" |  grep -o '^[^:]*')
+          echo "PKG_CONFIG_PATH_ORIG: ${PKG_CONFIG_PATH}"
+
+          export PKG_CONFIG_SYSTEM_INCLUDE_PATH_ORIG=$(echo "${PKG_CONFIG_SYSTEM_INCLUDE_PATH}" |  grep -o '^[^:]*')
+          echo "PKG_CONFIG_SYSTEM_INCLUDE_PATH_ORIG: ${PKG_CONFIG_SYSTEM_INCLUDE_PATH_ORIG}"
+
+          # For MSYS(mingw) and R environment variable R_ARCH and Rlib.dll.a.
+          # Need ONE single leftmost headish important library path.
+          export PKG_CONFIG_SYSTEM_LIBRARY_PATH_ORIG=$(echo "${PKG_CONFIG_SYSTEM_LIBRARY_PATH}" |  grep -o '^[^:]*')
+          # MSYS2(mingw) environments
+          # e.g. UCRT
+          # export PKG_CONFIG_SYSTEM_LIBRARY_PATH_ORIG="/ucrt64/lib"
+          echo "PKG_CONFIG_SYSTEM_LIBRARY_PATH_ORIG: ${PKG_CONFIG_SYSTEM_LIBRARY_PATH_ORIG}"
+
+          echo "PKG_CONFIG_PATH: ${PKG_CONFIG_PATH}"
+          echo "PKG_CONFIG_SYSTEM_INCLUDE_PATH: ${PKG_CONFIG_SYSTEM_INCLUDE_PATH}"
+          echo "PKG_CONFIG_SYSTEM_LIBRARY_PATH: ${PKG_CONFIG_SYSTEM_LIBRARY_PATH}"
+
+          # Garantee to find the PostgreSQL libraries.
+          # Some packages may also install an old "libpq" that is located in the default install location.
+          # We do not want to use that old "libpg" when compiling PL/R.
+          # Therefore, the PostgreSQL pkgconfig goes in front at the head.
+          #
+          export PKG_CONFIG_PATH="${PG_HOME}/lib/pkgconfig:${PKG_CONFIG_PATH}"
+          export PKG_CONFIG_SYSTEM_INCLUDE_PATH="${PG_HOME}/include:${PKG_CONFIG_SYSTEM_INCLUDE_PATH}"
+          export PKG_CONFIG_SYSTEM_LIBRARY_PATH="${PG_HOME}/bin:${PG_HOME}/lib:${PKG_CONFIG_SYSTEM_LIBRARY_PATH}"
+
+          echo "PKG_CONFIG_PATH: ${PKG_CONFIG_PATH}"
+          echo "PKG_CONFIG_SYSTEM_INCLUDE_PATH: ${PKG_CONFIG_SYSTEM_INCLUDE_PATH}"
+          echo "PKG_CONFIG_SYSTEM_LIBRARY_PATH: ${PKG_CONFIG_SYSTEM_LIBRARY_PATH}"
+
+          #### END PKGCONFIG SECTION ####
+
+          #### BEGIN MAKE POSTGRES INTO A LIBRARY ####
+
+          # This is Part 1 of 2 of a hack to make "meson" think that "libpostgres" is a library.
+          # From the libpq.pc file, create a libpostgres.pc file.
+          if [ ! -f "${PG_HOME}/lib/pkgconfig/libpostgres.pc" ]
+          then
+            cat "${PG_HOME}/lib/pkgconfig/libpq.pc" | sed "s/libpq/libpostgres/g" | sed "s/-lpq/-lpostgres/" > "${PG_HOME}/lib/pkgconfig/libpostgres.pc"
+          fi
+
+          # This is Part 2 of 2 of a hack to make "meson" think that "libpostgres" is a library
+          # libpostgres.exe.a is not recognized as a static library
+          # libpostgres.a     is     recognized as a static library
+          #                         # typical software repository default install
+          if [ ! -f "${PG_HOME}/lib/libpostgres.a" ] && [ ! -f "${PG_HOME}/lib/libpostgres.dll.a" ] && [ -f "${PG_HOME}/lib/libpostgres.exe.a" ]
+          then
+            # Note, a "meson built PostgreSQL install" will produce a file called "libpostgres.exe.a".
+            # cp -f   "${PG_HOME}/lib/libpostgres.exe.a" "${PG_HOME}/lib/libpostgres.a"
+            cp -f   "${PG_HOME}/lib/libpostgres.exe.a" "${PG_HOME}/lib/libpostgres.dll.a"
+          fi
+
+          ls -alrt "${PG_HOME}"/lib/libpostgres*
+
+          #### END MAKE POSTGRES INTO A LIBRARY ####
+
+          #### BEGIN MAKE R INTO A LIBRARY ####
+
+          # Make R into a library
+          if [ ! -d "${PKG_CONFIG_SYSTEM_LIBRARY_PATH_ORIG}/pkgconfig" ]
+          then
+            mkdir "${PKG_CONFIG_SYSTEM_LIBRARY_PATH_ORIG}/pkgconfig"
+          fi
+
+          if [ ! -f "${PKG_CONFIG_SYSTEM_LIBRARY_PATH_ORIG}/pkgconfig/libR.pc" ]
+          then
+            # Uses the provided template file "libR.pc"
+            # This template file is "based" off of the "R for Cygwin" file /lib/pkgconfig/libR.pc.
+            cat "libR.pc" | sed "s|R_HOME|${R_HOME}|" | sed "s|R_ARCH|${R_ARCH}|" | sed "s/rversion/${rversion}/" > "${PKG_CONFIG_SYSTEM_LIBRARY_PATH_ORIG}/pkgconfig/libR.pc"
+          fi
+
+          # Cygwin already has the file /usr/lib/R/lib/libR.dll.a
+          # MSYS2 (mingw) compilers require libR.dll.a.
+          # That file is created by ddltool program parameter "--output-lib".
+          #
+          # Note, Windows compilers (e.g. msvc) require R.lib.
+          # To create this file, instead of using the "dlltool" program, use the msvc "lib" program.
+          # Alternately, in the Windows "msvc" compiler case, just rename an archive dll.a to be a .lib,
+          # and that also works.
+          #
+          if [ ! -d "${PKG_CONFIG_SYSTEM_LIBRARY_PATH_ORIG}${R_ARCH}" ]
+          then
+            mkdir   "${PKG_CONFIG_SYSTEM_LIBRARY_PATH_ORIG}${R_ARCH}"
+          fi
+
+          # Create and Move, or, Copy, the R static library,
+          # to the target location - "${PKG_CONFIG_SYSTEM_LIBRARY_PATH_ORIG}${R_ARCH}/libR.dll.a"
+          if [ ! -f "${PKG_CONFIG_SYSTEM_LIBRARY_PATH_ORIG}${R_ARCH}/libR.dll.a" ]
+          then
+            #
+            # These should? be exclusive cases.
+            #
+            # Cygwin Repository R install case.
+            # Do I need to do this at all?
+            # If I am not given the R.dll, then THEY must provide the static library libR.dll.a.
+            if [ -f         "${PKG_CONFIG_SYSTEM_LIBRARY_PATH_ORIG}/R/lib/libR.dll.a" ]
+            then
+              pushd         "${PKG_CONFIG_SYSTEM_LIBRARY_PATH_ORIG}/R/lib"
+              cp libR.dll.a "${PKG_CONFIG_SYSTEM_LIBRARY_PATH_ORIG}${R_ARCH}/libR.dll.a"
+              popd # from   "${PKG_CONFIG_SYSTEM_LIBRARY_PATH_ORIG}/R/lib"
+            fi
+            # Msys case using "R for Windows" from CRAN
+            # If I am given the R.dll, then I can myself, create the static library libR.dll.a.
+            if [ -f "${R_HOME}/bin${R_ARCH}/R.dll" ]
+            then
+              pushd "${R_HOME}/bin${R_ARCH}"
+              gendef  -         R.dll >     R.def
+              dlltool --dllname R.dll --def R.def --output-lib libR.dll.a
+              #
+              # Put libR.dll.a into the general library location {...ORIG}${R_ARCH}/libR.dll.a
+              mv libR.dll.a "${PKG_CONFIG_SYSTEM_LIBRARY_PATH_ORIG}${R_ARCH}/libR.dll.a"
+              popd # from "${R_HOME}/bin${R_ARCH}"
+            fi
+          fi
+
+          #### END MAKE R INTO A LIBRARY ####
+
+          #### BEGIN CREATE THE PLR DIRECTORY ####
+
+          # Create the contribplr directory parallel to contrib.
+          # Copy all of the PL/R source code into contribplr.
+          #
+          mkdir     "${PG_HOME}/contrib"
+          #
+          mkdir     "${PG_HOME}/contribplr"
+          cp -R   * "${PG_HOME}/contribplr"
+          #
+          pushd     "${PG_HOME}/contribplr"
+
+          #### END CREATE THE PLR DIRECTORY ####
+
+          #### BEGIN SETUP MESON.BUILD FILES AND OPTIONS ####
+
+          mv  meson.build __meson.build.ROOT_CONTRIB_METHOD.HIDDEN
+          mv _meson.build   meson.build
+          mv _meson_options.txt meson_options.txt
+
+          #### END CREATE THE PLR DIRECTORY ####
+
+          #### BEGIN BUILD PLR AND TEST PLR ####
+
+          if [ "${Configuration}" == "Debug" ]
+          then
+            meson setup --prefix="${PG_HOME}/contrib/plr"                                   -Db_pie=true -DR_HOME="${R_HOME}" -DPG_HOME="${PG_HOME}" ../contrib/plr
+          fi
+
+          if [ "${Configuration}" == "Release" ]
+          then
+            meson setup --prefix="${PG_HOME}/contrib/plr" -Dbuildtype=release -Ddebug=false -Db_pie=true -DR_HOME="${R_HOME}" -DPG_HOME="${PG_HOME}" ../contrib/plr
+          fi
+
+          meson compile -C ../contrib/plr  -v
+
+          # install GOOD or BAD artifacts into NIX PG plr.dll and plr.dll.a.
+          #
+          if [ -f "../contrib/plr/plr.dll" ]
+          then
+            echo "plr.dll is found"
+            cp ../contrib/plr/plr.dll   "${PKGLIBDIR}"
+            ls -alrt                    "${PKGLIBDIR}/plr.dll"
+          fi
+          #
+          if [ -f "../contrib/plr/plr.dll.a" ]
+            echo "plr.dll.a is found"
+            then cp ../contrib/plr/plr.dll.a "${PKGLIBDIR}"
+            ls -alrt                         "${PKGLIBDIR}/plr.dll.a"
+          fi
+
+          #
+          # install GOOD OR BAD artifacts into NIX PG - support file - plr.control
+          #
+          cp plr.control "${SHAREDIR}/extension"
+          ls -alrt       "${SHAREDIR}/extension/plr.control"
+
+          #
+          # install GOOD OR BAD artifacts  into NIX PG - SQL support files - versioning "sql"
+          #
+          cp plr--*.sql  "${SHAREDIR}/extension"
+          ls -alrt        ${SHAREDIR}/extension/plr--*.sql
+
+          if [ "${OperatingSystem}" == "Cygwin" ]
+          then
+            echo "cygrunsrv START"
+            # shutdown current
+            #### cygrunsrv -E cygserver || true
+            # uninstall previous
+            #### cygrunsrv -R cygserver || true
+            # install
+            cygserver-config --yes
+            # postgresql failing with below error on lion os x
+            # https://stackoverflow.com/questions/6861945/postgresql-failing-with-below-error-on-lion-os-x#:~:text=Failed%20system%20call%20was%20shmget,the%20kernel%20with%20larger%20SHMMAX.
+            echo kern.ipc.shmall 4096 >>     /etc/defaults/etc/cygserver.conf
+            echo kern.ipc.shmmax 16777216 >> /etc/defaults/etc/cygserver.conf
+
+            # start
+            cygrunsrv -S cygserver
+          fi
+
+          echo "whoami: $(whoami)"
+
+          #
+          # Create and start the cluster before
+          # the non-setup regression test (see FAR below).
+          #
+          initdb -D ${WORKSPACE}/PGDATA
+          pg_ctl -D ${WORKSPACE}/PGDATA -l logfile start
+
+          # non-setup regression test
+          # Directories of testing "sql" and testing "expected" results exist here
+          #
+          # Some environments require it
+          export PGUSER=$(whoami)
+          echo "PGUSER: ${PGUSER}"
+          "${PKGLIBDIR}/pgxs/src/test/regress/pg_regress" --bindir="${PG_HOME}/bin" --dbname=pl_regression plr bad_fun opt_window do out_args plr_transaction opt_window_frame || (cat regression.diffs && false)
+
+          # Stop the cluster after
+          # the non-setup regression test (see above).
+          #
+          pg_ctl -D ${WORKSPACE}/PGDATA -l logfile stop
+
+          if [ "${OperatingSystem}" == "Cygwin" ]
+          then
+            echo "cygrunsrv STOP"
+            # shutdown current
+            cygrunsrv -E cygserver
+            # uninstall previous
+            #### cygrunsrv -R cygserver
+          fi
+
+          popd # from "${PG_HOME}/contribplr"
+          # back into WORKSPACE
+
+          #### END BUILD PG AND PLR AND TEST PLR ####
+
+          # save GOOD artifact plr.dll
+          #
+          if [ -f "${PG_HOME}/contrib/plr/plr.dll" ]
+          then
+            echo "Save plr.dll to be an artifact."
+            mkdir -p                                ${WORKSPACE}/tmp/lib
+            cp    LICENSE                           ${WORKSPACE}/tmp/PLR_LICENSE
+            cp    "${PG_HOME}/contrib/plr/plr.dll"  ${WORKSPACE}/tmp/lib
+            ls -alrt                                ${WORKSPACE}/tmp/lib/plr.dll
+            mkdir -p                                ${WORKSPACE}/tmp/share/extension
+            cp    *.control                         ${WORKSPACE}/tmp/share/extension
+            cp    *.sql                             ${WORKSPACE}/tmp/share/extension
+          fi
+
+          #
+          # save GOOD artifact plr.dll.a
+          #
+          if [ -f "${PG_HOME}/contrib/plr/plr.dll.a" ]
+          then
+            echo "Save plr.dll.a to be an artifact."
+            mkdir -p                                  ${WORKSPACE}/tmp/lib
+            cp    "${PG_HOME}/contrib/plr/plr.dll.a"  ${WORKSPACE}/tmp/lib
+            ls -alrt                                  ${WORKSPACE}/tmp/lib/plr.dll.a
+          fi
+
+          # 7z GOOD PL/R Artifact for LATER Release
+          echo "7z: $(which 7z)"
+          echo 7z a -r ${WORKSPACE}/plr-artifact.zip  ${WORKSPACE}/tmp/*
+          if [ -f "${WORKSPACE}/tmp/PLR_LICENSE" ]
+          then
+            echo "Create PL/R Artifact .zip for future Release"
+            7z a -r ${WORKSPACE}/plr-artifact.zip  ${WORKSPACE}/tmp/*
+          fi
+
+          # if "PostgreSQL for Windows" exists, then
+          # copy "Msys artifacts into "PostgreSQL for Windows" for future testing if env.MSYS2testonpgWIN == 'true'.
+          #
+          if ( [ ! "${PGROOT2}" == "notset" ] && [ ! "${PGROOT2}" == "" ] ) && [ "${OperatingSystem}" == "Msys" ]
+          then
+            export PGROOT2=$(cygpath "${PGROOT2}")
+            echo  "cygpath PGROOT2: ${PGROOT2}"
+
+            if [ -d "${PGROOT2}" ]
+            then
+              if [ -f "${PG_HOME}/contrib/plr/plr.dll" ]
+              then
+                echo "PGROOT2 is found. Preparing PostgreSQL for Windows testing."
+
+                cp  "${PG_HOME}/contrib/plr/plr.dll"   "${PGROOT2}/lib"
+                ls -alrt                               "${PGROOT2}/lib/plr.dll"
+                cp plr.control                         "${PGROOT2}/share/extension"
+                ls -alrt                               "${PGROOT2}/share/extension/plr.control"
+                cp plr--*.sql                          "${PGROOT2}/share/extension"
+                ls -alrt                               "${PGROOT2}"/share/extension/plr--*.sql
+
+              fi
+            fi
+          fi
+
+      - name: Windows     msvc Meson PL/R Setup Compile and Non-Meson Manual Test
+        if: ${{ env.os == 'windows-latest' && env.compilerClass == 'msvc' }}
+        env:
+          R_HOME: ${{ env.R_HOME }}
+          Platform: ${{ env.Platform }}
+          R_ARCH: ${{ env.R_ARCH }}
+          rversion: ${{ env.rversion }}
+          PG_HOME: ${{ env.PGROOT2 }} # different
+          PGVER2: ${{ env.PGVER2 }}
+        shell: powershell
+        run: |
+          systeminfo
+          if (Test-Path "C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe") {
+            ${env:msvcversion}   = $(& "C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe" -latest -property catalog_productLineVersion)
+            echo "msvcversion: ${env:msvcversion}"
+            ${env:msvcproductid} = $(& "C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe" -latest -property productId)
+            echo "msvcproductid: ${env:msvcproductid}"
+          }
+
+          echo "R_HOME: ${env:R_HOME}"
+          echo "Platform: ${env:Platform}"
+          echo "R_ARCH: ${env:R_ARCH}"
+          echo "rversion: ${env:rversion}"
+          echo "PG_HOME: ${env:PG_HOME}"
+          echo "PGVER2: ${env:PGVER2}"
+
+          ${env:WORKSPACE} = ${env:GITHUB_WORKSPACE}
+          echo "WORKSPACE: ${env:WORKSPACE}"
+
+          if("${env:R_HOME}" -eq ""){
+            Write-Error 'R_HOME is missing. Please supply the R_HOME.' -ErrorAction Stop
+          }
+          if("${env:R_ARCH}" -eq ""){
+            Write-Warning 'R_ARCH is missing. Is that the intention? One may supply the R_ARCH.'
+          }
+          if("${env:rversion}" -eq ""){
+            Write-Error 'rversion is missing. Please supply the rversion.' -ErrorAction Stop
+          }
+          if("${env:PG_HOME}" -eq ""){
+            Write-Error 'PG_HOME is missing. Please supply the PG_HOME.' -ErrorAction Stop
+          }
+          if("${env:PGVER2}" -eq ""){
+            Write-Error 'PGVER2 is missing. Please supply the PGVER2.' -ErrorAction Stop
+          }
+
+      - name: Try to Upload artifacts plr.dll and plr.dll.a for export for LOCAL testing
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v3
+        with:
+          name: plr-${{ env.HEAD8_GITHUB_SHA }}-${{ env.os }}-${{ env.compilerEnv }}-${{ env.Platform }}-R${{ env.rversion }}-PG${{ env.pgversion }}-${{ env.Configuration }}
+          # default
+          if-no-files-found: warn
+          path: |
+            tmp\*\*
+            tmp\PLR_LICENSE
+
+      - name: Set R_HOME and PG PATH, Start PG(read OS variables), Test on PostgreSQL for Windows
+        if: ${{ env.os == 'windows-latest' && env.compilerClass == 'MSYS2' && env.MSYS2testonpgWIN == 'true' }}
+        env:
+          R_HOME: ${{ env.R_HOME }}
+          R_ARCH: ${{ env.R_ARCH }}
+          #
+          PG_HOME: ${{ env.PGROOT2 }} # different
+          PGBIN2: ${{ env.PGBIN2 }}
+          #
+          PGVER2: ${{ env.PGVER2 }}
+          Platform: ${{ env.Platform }}
+        shell: cmd
+        run: |
+          echo on
+          echo R_HOME   - %R_HOME%
+          echo R_ARCH   - %R_ARCH%
+          echo PG_HOME  - %PG_HOME%
+          echo PGVER2   - %PGVER2%
+          echo PGBIN2   - %PGBIN2%
+          echo Platform - %Platform%
+
+          echo off
+          rem R     Sub-Architectures
+          if "%R_ARCH%"=="/x64"   set PATH=%R_HOME%\bin\x64;%PATH%
+          if "%R_ARCH%"=="/i386"  set PATH=%R_HOME%\bin\i386;%PATH%
+          rem not R Sub-Architectures
+          if "%R_ARCH%"=="notset" set PATH=%R_HOME%\bin;%PATH%
+
+          rem PostgreSQL for Windows, typically runs using
+          rem "Operating System Account: NT AUTHORITY\NetworkService"
+          rem R_HOME must be defined in the environment of the user that starts the postmaster process.
+
+          rem if I use chocolatey then uncomment this line.
+          rem Most chocolatey programs are located here, but not all.
+          rem set PATH="C:\ProgramData\chocolatey\bin";%PATH%
+
+          setx /M R_HOME "%R_HOME%"
+          setx /M PATH   "%PATH%"
+
+          echo M_PATH - %PATH%
+
+          rem Put MY pg_regress in the local PATH, in front of OTHER pg_regress that MAY BE installed.
+          set PATH=%PG_HOME%\bin;%PATH%
+
+          echo on
+          echo PGVER2   - %PGVER2%
+          echo Platform - %Platform%
+          rem Need to manually start PostgreSQL
+          if "%Platform%"=="x64" (net start postgresql-x64-%PGVER2%)
+          if "%Platform%"=="x86" (net start postgresql-%PGVER2%)
+          if "%Platform%"=="notset" (echo Platform is not set, therefore no net start happens.)
+
+          set PGUSER=postgres
+          set PGPASSWORD=root
+          "%PGBIN2%\pg_regress" --bindir="%PGBIN2%" --dbname=pl_regression plr bad_fun opt_window do out_args plr_transaction opt_window_frame || (type regression.diffs && call)
+          if "%ERRORLEVEL%"=="1" exit 1
+
+      - name: Stop PostgreSQL for Windows
+        if: ${{ env.os == 'windows-latest' && env.compilerClass == 'MSYS2' && env.MSYS2testonpgWIN == 'true' }}
+        env:
+          PGVER2: ${{ env.PGVER2 }}
+          Platform: ${{ env.Platform }}
+        shell: cmd
+        run: |
+          echo on
+          echo PGVER2   - %PGVER2%
+          echo Platform - %Platform%
+          rem Need to manually start PostgreSQL
+          if "%Platform%"=="x64" (net stop postgresql-x64-%PGVER2%)
+          if "%Platform%"=="x86" (net stop postgresql-%PGVER2%)
+          if "%Platform%"=="notset" (echo Platform is not set, therefore no net stop happens.)
+
+      - name: Windows Prep PL/R Artifact for Release
+        if: ${{ env.os == 'windows-latest' && ( env.compilerClass == 'MSYS2' || env.compilerClass == 'cygwin' || env.compilerClass == 'msvc' ) }}
+        env:
+          PGVER2: ${{ env.PGVER2 }}
+          Platform: ${{ env.Platform }}
+        shell: cmd
+        run: |
+          echo on
+          if exist plr-artifact.zip copy plr-artifact.zip plr-${{ env.HEAD8_GITHUB_SHA }}-${{ env.os }}-${{ env.compilerEnv }}-${{ env.Platform }}-R${{ env.rversion }}-PG${{ env.pgversion }}-${{ env.Configuration }}.zip
+          if exist plr-artifact.zip dir                   plr-${{ env.HEAD8_GITHUB_SHA }}-${{ env.os }}-${{ env.compilerEnv }}-${{ env.Platform }}-R${{ env.rversion }}-PG${{ env.pgversion }}-${{ env.Configuration }}.zip
+
+      # Testing is not done here.
+      # Pushing this tag assumes that the previous Github Actions workflow run had all 'successes'.
+      - name: PL/R Artifact for Release
+        if: github.ref_type == 'tag'
+        uses: ncipollo/release-action@v1
+        with:
+          allowUpdates: true
+          replacesArtifacts: true
+          # "artifacts" means "paths" and "files"
+          # set of paths representing artifacts to upload to the release
+          artifacts: |
+            plr-${{ env.HEAD8_GITHUB_SHA }}-${{ env.os }}-${{ env.compilerEnv }}-${{ env.Platform }}-R${{ env.rversion }}-PG${{ env.pgversion }}-${{ env.Configuration }}.zip
+          token: ${{ secrets.ACTIONS_CREATE_RELEASE_REPO_SECRET }}

--- a/.github/workflows/schedule.yml
+++ b/.github/workflows/schedule.yml
@@ -1,6 +1,8 @@
 # This is a basic workflow to help you get started with Actions
 
 name: plr daily
+run-name: plr daily - ${{ github.event.head_commit.message }}
+
 on:
   schedule:
     # * is a special character in YAML so you have to quote this string

--- a/Solution.pm.R
+++ b/Solution.pm.R
@@ -1,0 +1,88 @@
+
+CPlatform <- tail(commandArgs(),1)
+writeLines(paste0("CPlatform is ", CPlatform))
+
+# Required get the environment variable - postgresrcroot
+#
+# e.g. set postgresrcroot=C:\projects\postgresql
+#
+postgresrcroot <- Sys.getenv("postgresrcroot")
+postgresrcroot <- normalizePath(postgresrcroot, winslash="/", mustWork = T)
+
+SolutionPathFile <- paste0(postgresrcroot, "/src/tools/msvc/Solution.pm")
+Solution.pm.Lines <- readLines(SolutionPathFile)
+
+modifySubDeterminePlatform <- function(lines, CPlatform) {
+
+  # lines
+  LineOnlyBeginPos   <- which(grepl("sub\\s+DeterminePlatform", x = lines, perl = TRUE))
+  if(CPlatform == "Win32") {
+    LineAllHaveCPlatformPos <- which(grepl("x64", x = lines, perl = TRUE))
+  }
+  if(CPlatform == "x64") {
+    LineAllHaveCPlatformPos <- which(grepl("Win32", x = lines, perl = TRUE))
+  }
+  # after BeginPos, first-found line
+  if(CPlatform == "Win32") {
+    LineAllHaveCPlatformPos <- which(grepl("x64", x = lines, perl = TRUE))
+    LineOfCPlatformPos <- LineAllHaveCPlatformPos[head(which(LineOnlyBeginPos < LineAllHaveCPlatformPos),1L)]
+  }
+  # after BeginPos, second-found line
+  if(CPlatform == "x64") {
+    LineAllHaveCPlatformPos <- which(grepl("Win32", x = lines, perl = TRUE))
+    LineOfCPlatformPos <- LineAllHaveCPlatformPos[tail(head(which(LineOnlyBeginPos < LineAllHaveCPlatformPos),2L),1L)]
+  }
+
+  ModifyLineWorking <- lines[LineOfCPlatformPos]
+
+  # within that line
+
+  if(CPlatform == "Win32") {
+    LastCPlatformPos <- tail(gregexpr("x64", text = ModifyLineWorking, perl = TRUE)[[1L]],1L)
+  }
+  if(CPlatform == "x64") {
+    LastCPlatformPos <- tail(gregexpr("Win32", text = ModifyLineWorking, perl = TRUE)[[1L]],1L)
+  }
+
+  ModifyLineWorking <- strsplit(ModifyLineWorking, split = "")[[1L]]
+
+  # remove that CPlatform
+
+  ModifyLineWorking <- as.list(ModifyLineWorking)
+  if(CPlatform == "Win32") {
+    # remove "x64"
+    for(i in 1:3) {
+      ModifyLineWorking[LastCPlatformPos] <- NULL
+    }
+  }
+  if(CPlatform == "x64") {
+    # remove "Win32"
+    for(i in 1:5) {
+      ModifyLineWorking[LastCPlatformPos] <- NULL
+    }
+  }
+
+  ModifyLineWorking <- unlist(ModifyLineWorking)
+  ModifyLineWorking <- paste0(ModifyLineWorking, collapse = "")
+
+  # insert into the line at the old-CPlatform position
+  ModifyLineWorking <- paste0(append(strsplit(ModifyLineWorking, split = "")[[1L]], CPlatform, after = LastCPlatformPos - 1L), collapse = "")
+
+  lines[LineOfCPlatformPos] <- ModifyLineWorking
+
+  writeLines("")
+  writeLines("BEGIN modifySubDeterminePlatform ")
+  writeLines("")
+  writeLines(lines[LineOnlyBeginPos:LineOfCPlatformPos])
+  writeLines("")
+  writeLines("END   modifySubDeterminePlatform ")
+  writeLines("")
+
+  return(lines)
+
+}
+
+# part of sub DeterminePlatform - reduce concern to only "CPlatform"
+Solution.pm.Lines <- modifySubDeterminePlatform(Solution.pm.Lines, CPlatform = CPlatform )
+
+cat(file = SolutionPathFile, Solution.pm.Lines, sep = "\n")

--- a/_meson.build
+++ b/_meson.build
@@ -1,0 +1,89 @@
+project('plr', 'c',
+  version : '8_4_6',
+  license : 'GNU Public License Version 2',
+)
+
+R_home = get_option('R_HOME')
+if R_home == ''
+  error('One must supply: -DR_HOME=newvalue')
+endif
+
+pg_home = get_option('PG_HOME')
+if pg_home == ''
+  error('One must supply: -DPG_HOME=newvalue')
+endif
+
+plr_sources = files(
+  'plr.c',
+  'pg_conversion.c',
+  'pg_backend_support.c',
+  'pg_userfuncs.c',
+  'pg_rsupport.c',
+)
+
+plr_deps = []
+dep_libR = dependency('libR', required : true)
+plr_deps += dep_libR
+dep_libpq = dependency('libpq', required : true)
+plr_deps += dep_libpq
+dep_libpostgres = dependency('libpostgres', required : true)
+plr_deps += dep_libpostgres
+
+plr_incdir = []
+pg_incdir1= include_directories(R_home / 'include')
+plr_incdir += pg_incdir1
+pg_incdir2 = include_directories(pg_home / 'include' / 'postgresql' / 'server' )
+plr_incdir += pg_incdir2
+#  mingw
+pg_incdir3 = include_directories(pg_home / 'include' / 'postgresql' / 'server' / 'port' / 'win32' )
+plr_incdir += pg_incdir3
+
+# Refactor DLSUFFIX handling (PostreSQL 15 AND newer)
+# https://github.com/postgres/postgres/commit/23119d51a14c046dae35ae5e6ad9e35982d044fd
+#
+# PostgreSQL 14 and older
+# USE_PGXS=1 make CPPFLAGS=-DDLSUFFIX=\".so\"
+# https://github.com/postgres-plr/plr/issues/4
+#
+plr_c_args = []
+#
+# Detect MinGW host #8776
+# https://github.com/mesonbuild/meson/issues/8776
+#
+# Operating system names
+# https://mesonbuild.com/Reference-tables.html#operating-system-names
+#
+if ((host_machine.system() == 'windows') or (host_machine.system()  == 'cygwin'))
+  message('begin -DDLSUFFIX=".dll"')
+  dlsuffix = '-DDLSUFFIX=".dll"'
+  message('end   -DDLSUFFIX=".dll"')
+endif
+
+if host_machine.system() == 'linux'
+  dlsuffix = '-DDLSUFFIX=".so"'
+endif
+if host_machine.system() == 'darwin'
+  dlsuffix = '-DDLSUFFIX=".dylib"'
+endif
+plr_c_args += dlsuffix
+
+plr = shared_module('plr',
+  plr_sources,
+  c_args: plr_c_args,
+  name_prefix : '',
+  include_directories: plr_incdir,
+  dependencies: plr_deps,
+)
+
+if meson.version().version_compare('>=0.57')
+
+  summary(
+    {
+      'libR'               : dep_libR,
+      'libpq'              : dep_libpq,
+      'libpostgres (fake)' : dep_libpostgres,
+    },
+    section: 'Required Dependencies',
+  )
+
+endif

--- a/_meson.build.Test_the_detection_of_the_dependency_libR
+++ b/_meson.build.Test_the_detection_of_the_dependency_libR
@@ -1,0 +1,7 @@
+
+
+project('Test the detection of the dependency libR',
+  ['c']
+)
+
+dep_R = dependency('libR')

--- a/_meson.build.Test_the_detection_of_the_dependency_libpostgres
+++ b/_meson.build.Test_the_detection_of_the_dependency_libpostgres
@@ -1,0 +1,7 @@
+
+
+project('Test the detection of the dependency libpostgres',
+  ['c']
+)
+
+dep_postgres = dependency('libpostgres')

--- a/_meson.build.Test_the_detection_of_the_dependency_libpq
+++ b/_meson.build.Test_the_detection_of_the_dependency_libpq
@@ -1,0 +1,7 @@
+
+
+project('Test the detection of the dependency libpq',
+  ['c']
+)
+
+dep_pq = dependency('libpq')

--- a/_meson_options.txt
+++ b/_meson_options.txt
@@ -1,0 +1,5 @@
+
+
+option('R_HOME',  type : 'string', value : '', description : 'Path before the R "include" directory')
+option('PG_HOME', type : 'string', value : '', description : 'Path before the PostgreSQL "include" directory')
+

--- a/_meson_options.txt_postgres_root_additional_plr_option.txt
+++ b/_meson_options.txt_postgres_root_additional_plr_option.txt
@@ -1,0 +1,6 @@
+
+# 1. - add  subdir('plr')      to the file: postres/contrib/meson.build
+
+# 2. append this line below    to the file: postgres/meson_options.txt
+
+option('R_HOME', type : 'string', value : '', description : 'In R, the return value of R.home(). When using "--backend vs", this options is written with a colon(:) and backslashes(\)')

--- a/after_build.sh
+++ b/after_build.sh
@@ -1,0 +1,135 @@
+
+cd "$(dirname "$0")"
+
+. ./init.sh
+
+logok "BEGIN after_build.sh"
+
+set -v -x -e
+# set -e
+
+# put this in all non-init.sh scripts - pgroot is empty, if using an msys2 binary
+# but psql is already in the path
+if [ -f "${pgroot}/bin/psql" ]
+then
+  export PATH=${pgroot}/bin:${PATH}
+fi
+#
+# cygwin # pgroot: /usr - is the general location of binaries (psql) and already in the PATH
+#
+# $ echo $(cygpath "C:\cygwin\bin")
+# /usr/bin
+#
+# cygwin # initdb, postgres, and pg_ctl are here "/usr/sbin"
+if [ -f "${pgroot}/sbin/postgres" ]
+then
+  export PATH=${pgroot}/sbin:${PATH}
+fi
+
+pg_ctl -D ${PGDATA} -l logfile start
+
+if [ "${compiler}" == "msys2" ]
+then
+  winpty -Xallow-non-tty psql -d postgres --quiet --tuples-only -c "\pset footer off" -c "\timing off" -c "select current_setting('server_version_num')::integer;" --output=${APPVEYOR_BUILD_FOLDER}/server_version_num.txt
+else
+                         psql -d postgres --quiet --tuples-only -c "\pset footer off" -c "\timing off" -c "select current_setting('server_version_num')::integer;" --output=${APPVEYOR_BUILD_FOLDER}/server_version_num.txt
+fi
+
+
+# also used in compiler - msvc
+#
+./server_version_num.sh
+export server_version_num=$(cat ${APPVEYOR_BUILD_FOLDER}/server_version_num.txt)
+loginfo "server_version_num ${server_version_num}"
+#
+# also works
+# export A_VAR=$(echo -n $(sed -r 's/\s+//g' a_version.txt))
+
+loginfo "server_version_num ${server_version_num}"
+loginfo "OLD pgversion ${pgversion}"
+loginfo "OLD pg ${pg}"
+#
+# override - msys2 and cygwin binary case
+if [ "${pg}" == "none" ]
+  then
+  export pg=$(postgres -V | grep -oP '(?<=\) ).*$')
+  loginfo "NEW pg ${pg}"
+  if [ ${server_version_num} -gt 999999 ]
+  then
+    export pgversion=$(echo ${pg} | grep -oP '^\d+')
+  else
+    export pgversion=$(echo ${pg} | grep -oP '^\d+[.]\d+')
+  fi
+  loginfo "NEW pgversion ${pgversion}"
+fi
+loginfo "OLD or NEW pgversion ${pgversion}"
+
+pg_config | grep "^PKGLIBDIR\|^SHAREDIR" | sed "s/ = /=/" | sed s"/^/export /" > newvars.sh
+. ./newvars.sh
+
+mkdir                                 tmp
+cp LICENSE                            tmp/PLR_LICENSE
+mkdir -p                              tmp/lib
+cp ${PKGLIBDIR}/plr.dll               tmp/lib
+mkdir -p                              tmp/share/extension
+cp ${SHAREDIR}/extension/plr.control  tmp/share/extension
+cp ${SHAREDIR}/extension/plr--*.sql   tmp/share/extension
+
+if ([ "${rversion}" == "" ] || [ "${rversion}" == "none" ])
+then
+  # later(now) - dynamically determing the R version
+  #
+  # Tomas Kalibera custom build may contain spaces 
+  # so gsub replaces spaces with underscores
+  # 
+  # avoid cywin error - WARNING: ignoring environment value of R_HOME
+  export R_HOME_OLD=${R_HOME}
+  unset R_HOME
+  export rversion=$(Rscript --vanilla -e 'cat(gsub('\'' '\'', replacement = '\''_'\'', x = paste0(R.version$major,'\''.'\'',R.version$minor,tolower(R.version$status))))' 2>/dev/null)
+  export R_HOME=${R_HOME_OLD}
+fi
+
+export var7z=plr-${gitrevshort}-pg${pgversion}-R${rversion}${rversion_more}-${Platform}-${Configuration}-${compiler}.7z
+loginfo "${var7z}"
+
+echo ${APPVEYOR_BUILD_FOLDER}
+
+loginfo "BEGIN plr 7z CREATION"
+7z a -t7z -mmt24 -mx7 -r  ${APPVEYOR_BUILD_FOLDER}/${var7z} ./tmp/*
+ls -alrt                  ${APPVEYOR_BUILD_FOLDER}/${var7z}
+loginfo "BEGIN plr 7z LISTING"
+7z l                      ${APPVEYOR_BUILD_FOLDER}/${var7z}
+loginfo "END   plr 7z LISTING"
+loginfo "END plr 7z CREATION"
+
+
+if [ "${compiler}" == "cygwin" ]
+then
+  # command will automatically pre-prepend A DIRECTORY (strange!)
+  # e.g. 
+  pushd ${APPVEYOR_BUILD_FOLDER}
+  loginfo "appveyor PushArtifact ${var7z}"
+           appveyor PushArtifact ${var7z}
+  popd
+  #
+  # BAD PUSH-ARTIFACT - DEFINITELY A BUG
+  #
+  # loginfo "appveyor PushArtifact ${APPVEYOR_BUILD_FOLDER}/${var7z}"
+  #          appveyor PushArtifact ${APPVEYOR_BUILD_FOLDER}/${var7z}
+  #
+  # appveyor PushArtifact /cygdrive/c/projects/plr/plr-761a5fbc-pg12-R4.1.0alpha-x86-Debug-cygwin.7z
+  # File not found: C:\projects\plr\cygdrive\c\projects\plr\plr-761a5fbc-pg12-R4.1.0alpha-x86-Debug-cygwin.7z
+  # Command exited with code 2
+  # 
+else
+  loginfo "appveyor PushArtifact ${APPVEYOR_BUILD_FOLDER}/${var7z}"
+           appveyor PushArtifact ${APPVEYOR_BUILD_FOLDER}/${var7z}
+fi
+
+# must stop, else Appveyor job will hang.
+pg_ctl -D ${PGDATA} -l logfile stop
+
+set +v +x +e
+# set +e
+
+logok "END   after_build.sh"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,322 +1,1413 @@
+
+# Skipping commits affecting specific files (GitHub and Bitbucket only).
+skip_commits:
+  files:
+    # skipping AppVeyor build if, in the push’s head commit, all of the files
+    # have the extension .md
+    - '**/*.md'
+
 image: Visual Studio 2015
-configuration: Release
-platform: x64
 clone_depth: 1
 
 environment:
-
-  PGUSER: postgres
-  PGPASSWORD: Password12!
+  # Always Try to save
+  APPVEYOR_SAVE_CACHE_ON_ERROR: true
 
   matrix:
 
-  - pg: master
-    PlatformToolset: v141
-    configuration: Debug
-    APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2022
-    rversion: 4.2.3
+  # cygwin - late September 2023
+  # cygwin - all cygwin work - except x86 "dragon" "archive" - binaries are not available
 
-  - pg: REL_16_BETA1
-    PlatformToolset: v143
-    configuration: Debug
-    APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2022
-    rversion: 4.2.3
+##  - pg: master # non-static commit - from git
+##    PlatformToolset: v143
+##    Configuration: Debug
+##    Platform: x64
+##    APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2022
+##    # rversion - from the already compiled "Cygwin R" - 4.3.0-1 - September 2023 - cygwin.com/packages/summary/R.html
+##    compiler: cygwin
+##
+##  - pg: master # non-static commit - from git
+##    PlatformToolset: v143
+##    Configuration: Debug
+##    Platform: x86
+##    APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2022
+##    # rversion - from the already compiled "Cygwin R" - 4.3.0-1 - September 2023 - cygwin.com/packages/summary/R.html
+##    compiler: cygwin
+##
+##  - pg: REL_16_RC1 # static commit - from git
+##    PlatformToolset: v143
+##    Configuration: Debug
+##    Platform: x64
+##    APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2022
+##    # rversion - from the already compiled "Cygwin R" - 4.3.0-1 - September 2023 - cygwin.com/packages/summary/R.html
+##    compiler: cygwin
+##
+##  - pg: REL_16_RC1 # static commit - from git
+##    PlatformToolset: v143
+##    Configuration: Debug
+##    Platform: x86
+##    APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2022
+##    # rversion - from the already compiled "Cygwin R" - 4.3.0-1 - September 2023 - cygwin.com/packages/summary/R.html
+##    compiler: cygwin
+##
+##  - pg: REL_15_4 # static commit - from git
+##    PlatformToolset: v143
+##    Configuration: Debug
+##    Platform: x64
+##    APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2022
+##    # rversion - from the already compiled "Cygwin R" - 4.3.0-1 - September 2023 - cygwin.com/packages/summary/R.html
+##    compiler: cygwin
+##
+##  - pg: REL_15_4 # static commit - from git
+##    PlatformToolset: v143
+##    Configuration: Debug
+##    Platform: x86
+##    APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2022
+##    # rversion - from the already compiled "Cygwin R" - 4.3.0-1 - September 2023 - cygwin.com/packages/summary/R.html
+##    compiler: cygwin
+##
+##  # from the already compiled "Cygwin PostgreSQL" - 15.3-1 - September 2023 - https://cygwin.com/packages/summary/postgresql-src.html
+##  - PlatformToolset: v143
+##    Configuration: Release
+##    Platform: x64
+##    APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2022
+##    # rversion - from the already compiled "Cygwin R" - 4.3.0-1 - September 2023 - cygwin.com/packages/summary/R.html
+##    compiler: cygwin
 
-  - pg: REL_15_3
-    PlatformToolset: v143
-    configuration: Debug
+  # from the "last" compiled "Cygwin PostgreSQL" - in December 2022 - https://cygwin.com/packages/summary/postgresql-src.html
+  - PlatformToolset: v143
+    Configuration: Release
+    Platform: x86
     APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2022
-    rversion: 4.2.3
+    # rversion - from the already compiled "Cygwin R"  - in December 2022 - cygwin.com/packages/summary/R.html
+    compiler: cygwin
 
-  - pg: 15.3-2
+#   # x86 "dragon" "archive" (binaries are not easily available)
+#
+#   # plr to work with
+#   # MobaXterm Version 22.2 (2022-11-15) through the recent Version 23.2 (2023-06-25) and later?
+#   # from the "last" compiled "Cygwin PostgreSQL" - in September 2022 - https://cygwin.com/packages/summary/postgresql-src.html
+#   - PlatformToolset: v143
+#     Configuration: Debug
+#     Platform: x86
+#     APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2022
+#     # rversion - from the already compiled "Cygwin R"  - in September 2022 - cygwin.com/packages/summary/R.html
+#     compiler: cygwin
+#     archive: mobaxterm232 # or alternately "mobaxterm"
+
+
+#   # msys2 - late September 2023
+#   # msys2
+
+##  - pg: master # branch - non-static commit - from git
+##    PlatformToolset: v143
+##    Configuration: Debug
+##    Platform: x64
+##    APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2022
+##    rversion: 4.3.1
+##    compiler: msys2
+##
+##  - pg: REL_16_RC1 # static commit - from git
+##    PlatformToolset: v143
+##    Configuration: Debug
+##    Platform: x64
+##    APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2022
+##    rversion: 4.3.1
+##    compiler: msys2
+##
+##  - pg: REL_15_4 # static commit - from git # binary distributer version is volitile
+##    PlatformToolset: v143
+##    Configuration: Debug
+##    Platform: x64
+##    APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2022
+##    rversion: 4.3.1
+##    compiler: msys2
+##
+##    # from the already compiled "MINGW64 PostgreSQL" - 15.3-2 - September 2023 - packages.msys2.org/package/mingw-w64-x86_64-postgresql
+##    # none - from the repository - September 2023 - pg 15.3-2
+##  - PlatformToolset: v143
+##    Configuration: Debug
+##    Platform: x64
+##    APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2022
+##    rversion: 4.3.1
+##    compiler: msys2
+
+    # msvc/msys2? - "pg" 10     - last version "pg" supports x86
+    # msvc/msys2? - "r"   4.1.3 - last version "r"  supports x86
+
+  - pg: REL_10_23 # static commit - from git
     PlatformToolset: v143
-    APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2022
-    rversion: 4.2.3
-    
-  - pg: 15.3-2
-    PlatformToolset: v143
+    Configuration: Debug
+    Platform: x86
     APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2022
     rversion: 4.1.3
+    compiler: msys2
 
-  - pg: 14.8-2
-    PlatformToolset: v143
-    APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2022
-    rversion: 4.2.3
+#   # msvc - late September 2023
+#   # msvc
 
-  - pg: 14.8-2
-    PlatformToolset: v143
-    APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2022
-    rversion: 4.1.3
-
-  - pg: 13.11-2
-    PlatformToolset: v143
-    APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2022
-    rversion: 4.2.3
-
-  - pg: 13.11-2
-    PlatformToolset: v143
-    APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2022
-    rversion: 4.1.3
-
-  - pg: 12.15-2
-    PlatformToolset: v143
-    APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2022
-    rversion: 4.2.3
-
-  - pg: 12.15-2
-    PlatformToolset: v143
-    APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2022
-    rversion: 4.1.3
-
-  - pg: 11.20-2
-    PlatformToolset: v140
-    APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-    rversion: 4.2.3
-
-  - pg: 11.20-2
-    PlatformToolset: v140
-    APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-    rversion: 4.1.3
+  # msvc - "pg" 10     - last version "pg" supports x86
+  # msvc - "r"   4.1.3 - last version "r"  supports x86
 
   - pg: 10.23-1
     PlatformToolset: v120
-    APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-    rversion: 4.2.3
-
-  - pg: 10.23-1
-    PlatformToolset: v120
+    Configuration: Release
+    Platform: x86
     APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
     rversion: 4.1.3
+    compiler: msvc
+
+  - pg: REL_10_23 # verify can compile pgsql.sln on msvc 2015
+    PlatformToolset: v120
+    Configuration: Debug
+    Platform: x86
+    APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+    rversion: 4.1.3
+    compiler: msvc
+
+#   # msvc - late September 2023 - the rest are 64bit builds
+#   # msvc
+
+  - pg: master # non-static commit - from git
+    PlatformToolset: v143
+    Configuration: Debug
+    Platform: x64
+    APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2022
+    rversion: 4.2.3
+    compiler: msvc
+
+  - pg: REL_16_0 # static commit - from git
+    PlatformToolset: v143
+    Configuration: Debug
+    Platform: x64
+    APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2022
+    rversion: 4.2.3
+    compiler: msvc
+
+  - pg: 16.0-1
+    PlatformToolset: v143
+    Configuration: Release
+    Platform: x64
+    APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2022
+    rversion: 4.2.3
+    compiler: msvc
+
+  - pg: 15.4-1
+    PlatformToolset: v143
+    Configuration: Release
+    Platform: x64
+    APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2022
+    rversion: 4.2.3
+    compiler: msvc
+
+  - pg: 14.9-1
+    PlatformToolset: v143
+    Configuration: Release
+    Platform: x64
+    APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2022
+    rversion: 4.2.3
+    compiler: msvc
+
+  - pg: 13.12-1
+    PlatformToolset: v143
+    Configuration: Release
+    Platform: x64
+    APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2022
+    rversion: 4.2.3
+    compiler: msvc
+
+  - pg: 12.16-1
+    PlatformToolset: v143
+    Configuration: Release
+    Platform: x64
+    APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2022
+    rversion: 4.2.3
+    compiler: msvc
+
+  - pg: REL_11_21 # verify can compile pgsql.sln on msvc 2017
+    PlatformToolset: v140
+    Configuration: Debug
+    Platform: x64
+    APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+    rversion: 4.2.3
+    compiler: msvc
+
+  - pg: 11.21-1
+    PlatformToolset: v140
+    Configuration: Release
+    Platform: x64
+    APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+    rversion: 4.2.3
+    compiler: msvc
 
 matrix:
   allow_failures:
     - pg: master
 
-init: 
-- echo compiler msvc init
-- systeminfo
-# https://stackoverflow.com/questions/5089389/how-can-i-check-what-version-edition-of-visual-studio-is-installed-programmatica
-- if not "%APPVEYOR_BUILD_WORKER_IMAGE%"=="Visual Studio 2015" "C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe" -latest -property productId
-- if not "%APPVEYOR_BUILD_WORKER_IMAGE%"=="Visual Studio 2015" "C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe" -latest -property catalog_productLineVersion
-# Make %x64% available for caching
-- ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
-# a variable used in the Appveyor cache area must be defined in the init
-- ps: |
-    if ("$env:Platform" -eq "x64") {
-      $env:pf = "$env:ProgramFiles"
-      $env:x64 = "-x64"
-    } else {
-      $env:pf = "${env:ProgramFiles(x86)}"
-    }
-    $env:exe = "postgresql-$env:pg-windows$env:x64.exe"
-    [Environment]::SetEnvironmentVariable("exe", $env:exe, "Machine")
+for:
 
-    if ("${env:Platform}" -eq "x64") {
-      ${env:bit} = "64"
-    } else {
-      ${env:bit} = "32"
-    }
-    ${env:betterperl} = "strawberry${env:bit}"
-    ${env:betterperlurl} = "https://strawberryperl.com/download/5.32.1.1/strawberry-perl-5.32.1.1-${env:bit}bit-portable.zip"
+-
+  matrix:
+    only:
+      - compiler: cygwin
 
-- set exe=postgresql-%pg%-windows%x64%.exe
-- setx /m exe %exe%
+  # mileage from cygwin 32bit will vary
+  # https://cran.r-project.org/doc/manuals/r-release/R-admin.html#Cygwin
 
-install:
-- if not exist R-%rversion%-win.exe appveyor downloadfile https://cran.r-project.org/bin/windows/base/old/%rversion%/R-%rversion%-win.exe
-- R-%rversion%-win.exe /VERYSILENT
-# We could have used RTools many R users have, but let's use msys64 existing on Appveyor intead
-#- if not exist Rtools35.exe appveyor downloadfile https://cran.r-project.org/bin/windows/Rtools/Rtools35.exe
-#- Rtools35.exe /VERYSILENT
-- Set mingw=C:\msys64\mingw
-#
-# From the EnterpriseDB version name,
-# if any, strip off the: right-most part dot, then numbers, then one hyphen, then numbers.
-- ps: $env:pgversion = $env:pg -replace "[.]\d+-\d+$", ""
-#
-- echo pgversion=%pgversion%
-- set pgroot=%pf%\PostgreSQL\%pgversion%
-- echo %pgroot%
-- SET R_HOME=%ProgramFiles%\R\R-%rversion%
-- set RBIN=%PLATFORM:x86=i386%
-- SET sed=C:\msys64\usr\bin\sed
+  init:
+  - echo compiler cygwin init
+  - systeminfo
+  # https://stackoverflow.com/questions/5089389/how-can-i-check-what-version-edition-of-visual-studio-is-installed-programmatica
+  - if not "%APPVEYOR_BUILD_WORKER_IMAGE%"=="Visual Studio 2015" "C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe" -latest -property productId
+  - if not "%APPVEYOR_BUILD_WORKER_IMAGE%"=="Visual Studio 2015" "C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe" -latest -property catalog_productLineVersion
+  - if     "%APPVEYOR_BUILD_WORKER_IMAGE%"=="Visual Studio 2015" echo APPVEYOR_BUILD_WORKER_IMAGE is 2015
+  # Make %x64% available for caching
+  # a variable used in the Appveyor cach area must be defined in the init
+  - set gitrevshort=%APPVEYOR_REPO_COMMIT:~0,8%
+  - ps: |
+      # Set-PSDebug -Trace 2
 
-# Appveyor specific: seems not required - with Appveyor - Strawberry perl is already in the path
-# ActiveState Perl is good, but Strawberry Perl is preferred
-#
-- ps: |
-    # Set-PSDebug -Trace 2
-    if (-not (Test-Path "${env:betterperl}.zip")) {
-      curl -o "${env:betterperl}.zip" -v "${env:betterperlurl}"
-    }
-    7z x    "${env:betterperl}.zip" "-oc:\${env:betterperl}"
-    # of needed to install pl/perl
-    ${env:PATH} = "c:\${env:betterperl}\perl\bin;${env:PATH}"
-    which perl
-    ${env:PATH} = "${env:PATH};c:\${env:betterperl}\c\bin"
-    which pexports
-
-
-# R in the path is not required: msvc compilation
-# R in the path is required: find Rscript
-- set PATH=%R_HOME%\bin\%rbin%;%PATH%
-# environment variable "postgresrcroot" is required for msvc.diff.R
-- set postgresrcroot=C:\projects\postgresql
-
-- ps: |
-    # "branchtagcommit" exists only because, this makes an easier test in a windows batch
-    # This environment variable is use in a test that is used that is used in determining
-    # whether or not to perform patching (see below).
-    #
-    if ("${env:pg}" -notmatch "[.]") {
-      ${env:branchtagcommit} = "yes"
-    } else {
-      ${env:branchtagcommit} = "no"
-    }
-    echo "branchtagcommit ${env:branchtagcommit}"
-
-- ps: |
-    # notmatch - if no "dot is found" in pg name, then pg is a: git: branch, tag, or commit.
-    if ("${env:branchtagcommit}" -eq "yes") {
-      $env:Path += ";C:\msys64\usr\bin;C:\msys64\mingw64\bin;C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\bin\amd64"
-      git config --global advice.detachedHead false
-      #
-      # git commit
-      #
-      if(("${env:pg}" -cmatch  "^[a-z0-9]+$") -and ("${env:pghint}" -eq "commit")) {
-        git clone -q  https://git.postgresql.org/git/postgresql.git  c:\projects\postgresql
-        pushd c:\projects\postgresql
-        git checkout -q  ${env:pg} -b ${env:pg}
-        popd
-      #
-      # git branch or tag(detached head)
-      # PostgreSQL case - git branches and tags have at least one capital letter - but expect mostly CAPS
-      #
-      } else {
-        git clone -q --depth 1 --branch ${env:pg} https://git.postgresql.org/git/postgresql.git  c:\projects\postgresql
-      }
-      gendef - "$env:R_HOME\bin\$env:rbin\R.dll" > "R$env:PLATFORM.def" 2> $null
-      lib "/def:R$env:PLATFORM.def" "/out:R$env:PLATFORM.lib" "/MACHINE:$env:PLATFORM"
-      pushd c:\projects\postgresql
-      pwd
-      cmd /c mklink /J contrib\plr $env:APPVEYOR_BUILD_FOLDER
-      Rscript --vanilla "${env:APPVEYOR_BUILD_FOLDER}\msvc.diff.R"
-      perl contrib\plr\buildsetup.pl
-      echo  "AFTER perl contrib\plr\buildsetup.pl CONTENTS OF C:\projects\postgresql\pgsql.sln"
-      type  C:\projects\postgresql\pgsql.sln
-      popd
-      pwd
-      $env:PROJ="C:\projects\postgresql\pgsql.sln"
-      $env:dll="c:\projects\postgresql\$env:CONFIGURATION\plr\plr.dll"
-    } else {
-      $env:PROJ="plr.vcxproj"
-      $env:dll="$($env:PLATFORM.replace('x86', '.'))\$env:CONFIGURATION\plr.dll"
-      if (-not (Test-Path "$env:pgroot\bin")) {
-        if (-not (Test-Path "$env:exe")) {
-          Start-FileDownload "http://get.enterprisedb.com/postgresql/$env:exe"
+      if ("${env:compiler}" -eq "cygwin") {
+        if ("${env:Platform}" -eq "x64") {
+          ${env:CYG_ARCH}  = "x86_64"
+          ${env:CYG_ROOT}  = "C:\cygwin64"
+          ${env:CYG_CACHE} = "C:\cygwin64\var\cache\setup"
+        } else {
+          ${env:CYG_ARCH}  = "x86"
+          ${env:CYG_ROOT}  = "C:\cygwin"
+          ${env:CYG_CACHE} = "C:\cygwin\var\cache\setup"
         }
-        & ".\$env:exe" --unattendedmodeui none --mode unattended --superpassword "$env:PGPASSWORD" --servicepassword "$env:PGPASSWORD" | Out-Null
-        Stop-Service "postgresql$env:x64-$env:pgversion"
       }
-    }
 
-#
-# Only when compiling pg from scratch.
-# If pg is not being compiled then pgsql.sln will not exist and not have been created.
-#
-# The semi-duplicate extra 'plr' entry in the pgsql.sln file 
-# prevents building if Microsoft Visual Studio is the version 2019 and greater.
-#
-- if exist C:\projects\postgresql\pgsql.sln if "%branchtagcommit%"=="yes" (
-    echo REMOVE plr ENTRY from pgsql.sln &
-    echo FILE BEFORE clean_pgsql_sln.sh C:\projects\postgresql\pgsql.sln &
-    type      C:\projects\postgresql\pgsql.sln &
-    bash -lc '/c/projects/plr/clean_pgsql_sln.sh' &
-    echo FILE AFTER clean_pgsql_sln.sh C:\projects\postgresql\pgsql.sln &
-    type      C:\projects\postgresql\pgsql.sln
-  )
+    # https://cygwin.com/mirrors.html and MobaXterm ~/.aptcyg/setup.ini
+    #
+    # CYG_MIRROR: http://cygwin.mirror.rafal.ca/
+  - set CYG_MIRROR="https://mirrors.kernel.org/sourceware/cygwin/"
+  - echo CYG_MIRROR %CYG_MIRROR%
+
+  - set CYG_SETUP_DOWNLOAD_URL="http://cygwin.com/setup-%CYG_ARCH%.exe"
+  - echo CYG_SETUP_DOWNLOAD_URL %CYG_SETUP_DOWNLOAD_URL%
+
+  #
+  # possible user provided in the matrix
+  # (for now, keep this area to be the same as "msys2" and NOT ALL "msys2" FEATURES are implemented)
+  #
+  - if not defined githubcache     set githubcache=false
+  - if not defined pghint          set pghint=none
+  - if not defined pg              set pg=none
+  - if not defined pglinkbinoldurl set pglinkbinoldurl=none
+  # not (yet) used in compiler cygwin
+  # - if not defined  rlinkbinoldurl set  rlinkbinoldurl=none
+  - if not defined rversion_more set rversion_more=-nodetails
+
+  install:
+  - echo compiler cygwin install
+  - ps: |
+      # Set-PSDebug -Trace 2
+      ${env:PATH} = "${env:CYG_ROOT}\bin;${env:PATH}"
+
+  # From the version
+  - ps: |
+      # Set-PSDebug -Trace 2
+      if("${env:pg}" -ne "none") {
+        ${env:pgversion} = ${env:pg}
+      }
+      # if pg equals none - msys2 binary case,
+      # then later in the .sh scripts, pgversion will be determined by SQL
+
+  #
+  # only used about a custom PostgreSQL build (not an CYGWIN already compiled binary)
+  #
+  # no quotes - IMPORTANT to pass to bash
+  - set pgroot=C:\PGINSTALL
+  - mkdir "%pgroot%"
+  #
+
+  # if "githubcache: true",
+  #   then use the git tag 0.0.0.0.0.GITHUBCACHE in github as a "cache" of
+  #   pg already-compiled-binaries.
+  #
+  - set pg7z=pg-pg%pgversion%-%Platform%-%Configuration%-%compiler%.7z
+  - set pggithubbincacheurl=https://github.com/AndreMikulec/plr/releases/download/0.0.0.0.0.GITHUBCACHE/%pg7z%
+  #
+  # note: using Windows instead of Powershell
+  # I could not get the Invoke-??? . . . I would silently run (and die), I would not get error feedback.
+  #
+  - if "%githubcache%"=="true" if not exist "%pg7z%"  (
+      bash --login -c "$(cygpath ${APPVEYOR_BUILD_FOLDER})/pggithubbincachefailingfound.sh" &
+      for /f "delims=" %%i in (%APPVEYOR_BUILD_FOLDER%\pggithubbincachefailingfound.txt) do (set pggithubbincachefailingfound=%%i)
+    )
+  - if "%githubcache%"=="true" if "%pggithubbincachefailingfound%"=="false" curl -o "%pg7z%" -L "%pggithubbincacheurl%"
+  - if "%githubcache%"=="true" if "%pggithubbincachefailingfound%"=="false" if exist "%pg7z%" (set pggithubbincachefound=true) else (set pggithubbincachefound=false)
+  - if "%githubcache%"=="true" if "%pggithubbincachefailingfound%"=="false" if "%pggithubbincachefound%"=="true" (
+        mkdir            "%pgroot%" &
+        7z x "%pg7z%"  "-o%pgroot%" &
+        dir              "%pgroot%" &
+        if exist "%pgroot%\bin\postgres.exe" (set pggithubbincacheextracted=true) else (set pggithubbincacheextracted=false)
+    )
+  #                            cygwin: executable IS STILL postgres.exe (not postgres)
+  # user provided (if any), in the matrix
+  - echo githubcache %githubcache%
+  # generated
+  # internal - do not reuse
+  - echo pggithubbincachefailingfound %pggithubbincachefailingfound%
+  # reused below
+  - echo pggithubbincachefound %pggithubbincachefound%
+  - if not defined pggithubbincachefound set pggithubbincachefound=false
+  - echo pggithubbincachefound %pggithubbincachefound%
+  # reused below
+  - echo pggithubbincacheextracted %pggithubbincacheextracted%
+  - if not defined pggithubbincacheextracted set pggithubbincacheextracted=false
+  - echo pggithubbincacheextracted %pggithubbincacheextracted%
+
+  #
+  # Remove (if any) old plr files, from the pg already-compiled-binary
+  # extraction from 0.0.0.0.0.GITHUBCACHE
+  #
+  - ps: |
+      # Set-PSDebug -Trace 2
+      if (("${env:githubcache}" -eq "true") -and ("${env:pggithubbincacheextracted}" -eq "true")) {
+        pushd "${env:pgroot}"
+        del share\extension\plr--*.sql   2>null
+        del share\extension\plr.control  2>null
+        del lib\plr.dll                  2>null
+        del symbols\plr.pdb              2>null
+        popd
+      }
+
+  #
+  # PostgreSQL from source code: git, tag, or commit
+  #
+  - ps: |
+      # Set-PSDebug -Trace 2
+      if (("${env:pggithubbincacheextracted}" -eq "false") -and ("${env:pg}" -ne "none")) {
+        git config --global advice.detachedHead false
+        $env:PATH += ";C:\msys64\usr\bin;C:\msys64\mingw64\bin;C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\bin\amd64"
+        #
+        # git branch or commit - alphanumeric and all lowercase letters (slower download)
+        #
+        if("${env:pghint}" -eq "commit") {
+          git clone -q                            https://git.postgresql.org/git/postgresql.git c:\projects\postgresql
+          pwd
+          pushd c:\projects\postgresql
+          pwd
+          git checkout -q                 ${env:pg} -b ${env:pg}
+          git branch
+          echo ${env:pg}
+          popd
+          pwd
+        #
+        # git branch or tag(detached head)
+        # PostgreSQL case - git branches and tags have at least one capital letter - but expect mostly CAPS
+        #
+        } else {
+          git clone -q --depth 1 --branch ${env:pg} https://git.postgresql.org/git/postgresql.git c:\projects\postgresql
+          pushd c:\projects\postgresql
+          pwd
+          git branch
+          echo ${env:pg}
+          popd
+          pwd
+        }
+        pushd c:\projects\postgresql
+        pwd
+        echo "Files . . ."
+        $Table = Get-ChildItem
+        foreach ($Row in $Table) { $Row.Name }
+        popd
+      }
+
+  - ps: |
+      # Somewhat safe to pass to Windows CMD
+      ${env:cunsupported} = " "
+
+      # specific - "archive" is "none" or "last" or undefined
+      #
+      ${env:cunsupported}  = "false"
+      #
+      if("${env:Platform}" -eq "x86" -and "${env:archive}" -eq "") {
+        ${env:CYG_MIRROR} = "http://mirrors.kernel.org/sourceware/cygwin-archive/20221123/"
+        ${env:cunsupported}  = "true"
+      }
+
+      # specific - "archive" is "mobaxterm" or "mobaxterm232"
+      if("${env:Platform}" -eq "x86" -and
+        ("${env:archive}" -eq "mobaxterm"    -or
+         "${env:archive}" -eq "mobaxterm232"
+        )) {
+        ${env:CYG_MIRROR} = "http://ctm.crouchingtigerhiddenfruitbat.org/pub/cygwin/circa/2022/06/12/123302/"
+        # override
+        ${env:CYG_SETUP_DOWNLOAD_URL} = "http://ctm.crouchingtigerhiddenfruitbat.org/pub/cygwin/setup/snapshots/setup-x86-2.919.exe"
+      }
+
+  - if "%cunsupported%"=="true"  set unsupported_flag="--allow-unsupported-windows"
+  - if "%cunsupported%"=="false" set unsupported_flag="  "
+
+  - echo CYG_SETUP_DOWNLOAD_URL %CYG_SETUP_DOWNLOAD_URL%
+
+  #  cywin AND PostreSQL development
+  - 'appveyor DownloadFile %CYG_SETUP_DOWNLOAD_URL% -FileName setup.exe'
+
+  - echo CYG_MIRROR %CYG_MIRROR%
+  - echo cunsupported %cunsupported%
+  - echo unsupported_flag %unsupported_flag% VALUE
+  - echo CYG_ROOT %CYG_ROOT%
+  - echo CYG_CACHE %CYG_CACHE%
+  - echo CYG_ARCH %CYG_ARCH%
+
+  # destroy appveyors already existing directories
+  - rmdir /S /Q "%CYG_ROOT%" || time /t
+
+  # cygwin install (verbose to help see HTTP 404 errors)
+  - echo setup.exe %unsupported_flag% -qnNdO -v -R "%CYG_ROOT%" -s "%CYG_MIRROR%" -l "%CYG_CACHE%"
+  - 'setup.exe %unsupported_flag% -qnNdO -v -R "%CYG_ROOT%" -s "%CYG_MIRROR%" -l "%CYG_CACHE%" || type "%CYG_ROOT%\var\log\setup.log.full" || type "%CYG_ROOT%\var\log\setup.log" || time /t'
+
+  # Windows server
+  - 'setup.exe %unsupported_flag% -qnNdO -R "%CYG_ROOT%" -s "%CYG_MIRROR%" -l "%CYG_CACHE%" -P cygrunsrv'
+
+  # postgres installation requirements that are not already covered by the other lines further down
+  - 'setup.exe %unsupported_flag% -qnNdO -R "%CYG_ROOT%" -s "%CYG_MIRROR%" -l "%CYG_CACHE%" -P gcc-core -P make -P tar -P gzip -P libreadline7 -P zlib -P icu-devel -P bison -P perl'
+
+  - 'setup.exe %unsupported_flag% -qnNdO -R "%CYG_ROOT%" -s "%CYG_MIRROR%" -l "%CYG_CACHE%" -P flex -P libreadline-devel -P libssl-devel -P libxml2-devel -P libxslt-devel -P openldap-devel -P zlib-devel'
+  #
+  # plr - andre - other packages - experience of need - while trying to - manually step by step build plr
+  - 'setup.exe %unsupported_flag% -qnNdO -R "%CYG_ROOT%" -s "%CYG_MIRROR%" -l "%CYG_CACHE%" -P libintl-devel -P libcrypt-devel'
+  #
+  # to archive and un-archive (7z)
+  - 'setup.exe %unsupported_flag% -qnNdO -R "%CYG_ROOT%" -s "%CYG_MIRROR%" -l "%CYG_CACHE%" -P p7zip'
+
+  #
+  - bash -login -c "cygserver-config --yes"
+  #
+  - copy %CYG_ROOT%\etc\defaults\etc\cygserver.conf %CYG_ROOT%\etc\defaults\etc\cygserver.conf.original
+  - echo kern.ipc.shmmni 32767 >> %CYG_ROOT%\etc\defaults\etc\cygserver.conf
+  - echo kern.ipc.shmseg 32767 >> %CYG_ROOT%\etc\defaults\etc\cygserver.conf
+  #
+  - bash -login -c "cygrunsrv -S cygserver"
+
+  # PostgreSQL on cygwin
+  # https://cygwin.com/cgi-bin2/package-grep.cgi?grep=postgresql&arch=x86_64
+  #
+  ### trying to add more -devel to try to solve a plr-make "lpostgres" linking error
+  - setup.exe %unsupported_flag% -qnNdO -R "%CYG_ROOT%" -s "%CYG_MIRROR%" -l "%CYG_CACHE%" -P postgresql-client -P postgresql -P postgresql-devel
+
+  # needs pg_config
+  # 1. USE_PGXS=1
+  # 2. new variables PKGLIBDIR SHAREDIR to determine the location of the new plr files (to be archived)
+  #
+  # PostgreSQL - from an CYGWIN already-compiled-binary - pg_config
+  ### trying to add more -devel to try to solve a plr-make "lpostgres" linking error
+  - setup.exe %unsupported_flag% -qnNdO -R "%CYG_ROOT%" -s "%CYG_MIRROR%" -l "%CYG_CACHE%" -P libpq-devel
+
+  # R on cygwin
+  # https://cygwin.com/cgi-bin2/package-grep.cgi?grep=R-&arch=x86
+  ###
+  ### NEED A CYGWIN COMPILED "R", so "rversion" (if any) is effectively ignored
+  ###
+  # only linking to the "R from cygwin"
+  ### - if "%pg%"=="none" ( )
+  - setup.exe %unsupported_flag% -qnNdO -R "%CYG_ROOT%" -s "%CYG_MIRROR%" -l "%CYG_CACHE%" -P R -P R-debuginfo
+
+  build_script:
+  #
+  # Note - cygwin DOES NOT do "R subarchitectures" - R_ARCH - "/x64" and "/i386"
+  # set
+  - set R_HOME=%CYG_ROOT%\lib\R
+  #
+  - bash --login -c "$(cygpath ${APPVEYOR_BUILD_FOLDER})/build_script.sh"
+
+  after_build:
+  - bash --login -c "$(cygpath ${APPVEYOR_BUILD_FOLDER})/after_build.sh"
+
+  test_script:
+  - bash --login -c "$(cygpath ${APPVEYOR_BUILD_FOLDER})/test_script.sh"
+
+-
+  matrix:
+    only:
+      - compiler: msys2
+
+  init:
+  - echo compiler msys2 init
+  - systeminfo
+  # https://stackoverflow.com/questions/5089389/how-can-i-check-what-version-edition-of-visual-studio-is-installed-programmatica
+  - if not "%APPVEYOR_BUILD_WORKER_IMAGE%"=="Visual Studio 2015" "C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe" -latest -property productId
+  - if not "%APPVEYOR_BUILD_WORKER_IMAGE%"=="Visual Studio 2015" "C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe" -latest -property catalog_productLineVersion
+  - if     "%APPVEYOR_BUILD_WORKER_IMAGE%"=="Visual Studio 2015" echo APPVEYOR_BUILD_WORKER_IMAGE is 2015
+  # Make %x64% available for caching
+  # a variable used in the Appveyor cach area must be defined in the init
+  - set gitrevshort=%APPVEYOR_REPO_COMMIT:~0,8%
+  - ps: |
+      # Set-PSDebug -Trace 2
+
+      if ("${env:compiler}" -eq "msys2") {
+        if ("${env:Platform}" -eq "x64") {
+          ${env:MSYSTEM} = "MINGW64"
+        } else {
+          ${env:MSYSTEM} = "MINGW32"
+        }
+      }
+
+      if ("${env:MSYSTEM}" -eq "MINGW64") {
+        ${env:R_ARCH} = "/x64"
+      } else {
+        ${env:R_ARCH} = "/i386"
+      }
+
+      ${env:rbinurl} = "https://cran.r-project.org/bin/windows/base/old/${env:rversion}/R-${env:rversion}-win.exe"
+      # "make installcheck" does not like spaces
+      ${env:R_HOME} = "C:\RINSTALL"
+      #
+      # also see that each *.sh dot sources early ". ./init.sh"
+
+      if ("${env:Platform}" -eq "x64") {
+        ${env:bit} = "64"
+      } else {
+        ${env:bit} = "32"
+      }
+      ${env:betterperl} = "strawberry${env:bit}"
+      ${env:betterperlurl} = "https://strawberryperl.com/download/5.32.1.1/strawberry-perl-5.32.1.1-${env:bit}bit-portable.zip"
+  #
+  # possible user provided in the matrix
+  #
+  - if not defined githubcache     set githubcache=false
+  - if not defined pghint          set pghint=none
+  - if not defined pg              set pg=none
+  - if not defined pglinkbinoldurl set pglinkbinoldurl=none
+  - if not defined  rlinkbinoldurl set  rlinkbinoldurl=none
+  - if not defined rversionurl set rversionurl=https://cran.r-project.org/bin/windows/base/old/%rversion%/R-%rversion%-win.exe
+  - if not defined rversion_more set rversion_more=-nodetails
+
+  install:
+  - echo compiler msys2 install
+  - ps: |
+      # Set-PSDebug -Trace 2
+      ${env:PATH} = "C:\msys64\${env:MSYSTEM}\bin;C:\msys64\usr\bin;C:\msys64\bin;${env:PATH}"
+
+  # - if not exist R-%rversion%-win.exe appveyor downloadfile https://cran.r-project.org/bin/windows/base/old/%rversion%/R-%rversion%-win.exe
+  - ps: |
+      # Set-PSDebug -Trace 2
+      # default
+      # special named R version(s)
+      if("${env:rlinkbinoldurl}" -eq "none") {
+        if("${env:rversion}" -match "beta|alpha|devel|patched") {
+          ${env:rversionurl} = "https://cran.r-project.org/bin/windows/base/R-${env:rversion}-win.exe"
+        }
+      } else {
+          # R general download (or a specific custom build)
+          ${env:rversionurl} = ${env:rlinkbinoldurl}
+      }
+      # .7z .zip .exe
+      ${env:rversionurl_download_ext} = [System.IO.Path]::GetExtension(${env:rversionurl})
+
+      # .7z .zip .exe # too many variants: not worth the time/code/headache/caching effort
+      if (Test-Path "R-${env:rversion}-win.exe") {
+        del         "R-${env:rversion}-win.exe"
+      }
+      #
+      # any download
+      # PowerShell 4.0, an Alias of "curl"
+      if(-not ("${env:rversionurl_download_ext}" -eq ".exe")) {
+        curl -o "R-${env:rversion}-win${env:rversionurl_download_ext}" -v "${env:rversionurl}"
+        7z e    "R-${env:rversion}-win${env:rversionurl_download_ext}" "R-${env:rversion}-win.exe"
+      } else {
+        curl -o "R-${env:rversion}-win.exe" -v "${env:rversionurl}"
+      }
+  #
+  - R-%rversion%-win.exe /VERYSILENT /DIR=%R_HOME% /NOICONS /TASKS=
+
+  # From the version
+  - ps: |
+      # Set-PSDebug -Trace 2
+      if("${env:pg}" -ne "none") {
+        ${env:pgversion} = ${env:pg}
+      }
+      # if pg equals none - msys2 binary case,
+      # then later in the .sh scripts, pgversion will be determined by SQL
+
+  #
+  # only used about a custom PostgreSQL build (not an MSYS2 already compiled binary)
+  #
+  # no quotes - IMPORTANT to pass to bash
+  - set pgroot=C:\PGINSTALL
+  - mkdir "%pgroot%"
+  #
+
+  #
+  # In powershell the (above) will not run/install
+  # neither plain as here, nor in Invoke-Command,
+  # (Perhaps because, of "some" complexity)
+
+  - ps: |
+      # Set-PSDebug -Trace 2
+      if (-not (Test-Path "${env:betterperl}.zip")) {
+        curl -o "${env:betterperl}.zip" -v "${env:betterperlurl}"
+      }
+      7z x    "${env:betterperl}.zip" "-oc:\${env:betterperl}"
+      # of needed to install pl/perl
+      ${env:PATH} = "c:\${env:betterperl}\perl\bin;${env:PATH}"
+      which perl
+      ${env:PATH} = "${env:PATH};c:\${env:betterperl}\c\bin"
+      which pexports
+  # note, if compiling PostgreSQL from source,
+  # then in the .sh files. one has to re-set the path
+  # xor append . . .
+  # export PATH=. . .etc . . .:${PATH}
+  # to the /etc/profile
+
+  #
+  # if "githubcache: true",
+  #   then use the git tag 0.0.0.0.0.GITHUBCACHE in github as a "cache" of
+  #   pg already-compiled-binaries.
+  #
+  - set pg7z=pg-pg%pgversion%-%Platform%-%Configuration%-%compiler%.7z
+  - set pggithubbincacheurl=https://github.com/AndreMikulec/plr/releases/download/0.0.0.0.0.GITHUBCACHE/%pg7z%
+  #
+  # note: using Windows instead of Powershell
+  # I could not get the Invoke-??? . . . I would silently run (and die), I would not get error feedback.
+  #
+  - if "%githubcache%"=="true" if not exist "%pg7z%"  (
+      bash --login -c "$(cygpath ${APPVEYOR_BUILD_FOLDER})/pggithubbincachefailingfound.sh" &
+      for /f "delims=" %%i in (%APPVEYOR_BUILD_FOLDER%\pggithubbincachefailingfound.txt) do (set pggithubbincachefailingfound=%%i)
+    )
+  - if "%githubcache%"=="true" if "%pggithubbincachefailingfound%"=="false" curl -o "%pg7z%" -L "%pggithubbincacheurl%"
+  - if "%githubcache%"=="true" if "%pggithubbincachefailingfound%"=="false" if exist "%pg7z%" (set pggithubbincachefound=true) else (set pggithubbincachefound=false)
+  - if "%githubcache%"=="true" if "%pggithubbincachefailingfound%"=="false" if "%pggithubbincachefound%"=="true" (
+        mkdir            "%pgroot%" &
+        7z x "%pg7z%"  "-o%pgroot%" &
+        dir              "%pgroot%" &
+        if exist "%pgroot%\bin\postgres.exe" (set pggithubbincacheextracted=true) else (set pggithubbincacheextracted=false)
+    )
+  #                            msys2: executable IS STILL postgres.exe (not postgres)
+  # user provided (if any), in the matrix
+  - echo githubcache %githubcache%
+  # generated
+  # internal - do not reuse
+  - echo pggithubbincachefailingfound %pggithubbincachefailingfound%
+  # reused below
+  - echo pggithubbincachefound %pggithubbincachefound%
+  - if not defined pggithubbincachefound set pggithubbincachefound=false
+  - echo pggithubbincachefound %pggithubbincachefound%
+  # reused below
+  - echo pggithubbincacheextracted %pggithubbincacheextracted%
+  - if not defined pggithubbincacheextracted set pggithubbincacheextracted=false
+  - echo pggithubbincacheextracted %pggithubbincacheextracted%
+
+  #
+  # Remove old plr files, from the pg already-compiled-binary
+  # extraction from 0.0.0.0.0.GITHUBCACHE, if any old files
+  #
+  # in the msys2 case, this will not happen (TODO: later remove this code)
+  #
+  - ps: |
+      # Set-PSDebug -Trace 2
+      if (("${env:githubcache}" -eq "true") -and ("${env:pggithubbincacheextracted}" -eq "true")) {
+        pushd "${env:pgroot}"
+        del share\extension\plr--*.sql   2>null
+        del share\extension\plr.control  2>null
+        del lib\plr.dll                  2>null
+        del symbols\plr.pdb              2>null
+        popd
+      }
+
+  #
+  # PostgreSQL from source code: git, tag, or commit
+  #
+  - ps: |
+      # Set-PSDebug -Trace 2
+      if (("${env:pggithubbincacheextracted}" -eq "false") -and ("${env:pg}" -ne "none")) {
+        git config --global advice.detachedHead false
+        $env:PATH += ";C:\msys64\usr\bin;C:\msys64\mingw64\bin;C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\bin\amd64"
+        #
+        # git branch or commit - alphanumeric and all lowercase letters (slower download)
+        #
+        if("${env:pghint}" -eq "commit") {
+          git clone -q                            https://git.postgresql.org/git/postgresql.git c:\projects\postgresql
+          pwd
+          pushd c:\projects\postgresql
+          pwd
+          git checkout -q                 ${env:pg} -b ${env:pg}
+          git branch
+          echo ${env:pg}
+          popd
+          pwd
+        #
+        # git branch or tag(detached head)
+        # PostgreSQL case - git branches and tags have at least one capital letter - but expect mostly CAPS
+        #
+        } else {
+          git clone -q --depth 1 --branch ${env:pg} https://git.postgresql.org/git/postgresql.git c:\projects\postgresql
+          pushd c:\projects\postgresql
+          pwd
+          git branch
+          echo ${env:pg}
+          popd
+          pwd
+        }
+        pushd c:\projects\postgresql
+        pwd
+        echo "Files . . ."
+        $Table = Get-ChildItem
+        foreach ($Row in $Table) { $Row.Name }
+        popd
+      }
+
+  # msys2
+  #
+  # Nov Dec 2021 Appveyor changed the PATH
+  # The [first] winpty.exe found is [the] "wrong [one]"
+  #
+  # Attempt to avoid the error:
+  #
+  # 1 [main] winpty (2980) C:\Program Files\Git\usr\bin\winpty.exe: *** fatal error - cygheap base mismatch detected
+  # This problem is probably due to using incompatible versions of the cygwin DLL
+  #
+  - bash --login -c "pacman --noconfirm -S --needed winpty"
+
+  # PostgreSQL from an MSYS2 already-compiled-binary.
+  - if "%pg%"=="none" (
+      bash --login -c "pacman --noconfirm -S --needed ${MINGW_PACKAGE_PREFIX}-postgresql"
+    )
+
+  #
+  # How to obtain older versions of packages using MSYS2?
+  # 2015
+  # https://stackoverflow.com/questions/33969803/how-to-obtain-older-versions-of-packages-using-msys2
+  #
+  - if "%pg%"=="none" if not "%pglinkbinoldurl%"=="none" (
+      bash -login -c "curl   -o             install.pkg.tar.zst ${pglinkbinoldurl}" &
+      bash -login -c "pacman -U --noconfirm install.pkg.tar.zst"
+    )
+
+  build_script:
+  - bash --login -c "$(cygpath ${APPVEYOR_BUILD_FOLDER})/build_script.sh"
+
+  after_build:
+  - bash --login -c "$(cygpath ${APPVEYOR_BUILD_FOLDER})/after_build.sh"
+
+  test_script:
+  - bash --login -c "$(cygpath ${APPVEYOR_BUILD_FOLDER})/test_script.sh"
+
+-
+  matrix:
+    only:
+      - compiler: msvc
+
+  environment:
+    #
+    # Appveyor PostgreSQL clusters specific
+    #
+    PGUSER: postgres
+    PGPASSWORD: Password12!
+    #
+    # PostgreSQL client session
+    #
+    PGOPTIONS: -c log_error_verbosity=verbose -c log_min_messages=debug2 -c log_min_error_statement=debug2
+    #
+
+  # Appveyor build server environment variables
+  #
+  # ProgramFiles=C:\Program Files
+  # ProgramFiles(x86)=C:\Program Files (x86)
+  #
+  init:
+  - echo compiler msvc init
+  - systeminfo
+  # https://stackoverflow.com/questions/5089389/how-can-i-check-what-version-edition-of-visual-studio-is-installed-programmatica
+  - if not "%APPVEYOR_BUILD_WORKER_IMAGE%"=="Visual Studio 2015" "C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe" -latest -property productId
+  - if not "%APPVEYOR_BUILD_WORKER_IMAGE%"=="Visual Studio 2015" "C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe" -latest -property catalog_productLineVersion
+  - if     "%APPVEYOR_BUILD_WORKER_IMAGE%"=="Visual Studio 2015" echo APPVEYOR_BUILD_WORKER_IMAGE is 2015
+  - ps: |
+      ${env:msvcversion} = "2015"
+      ${env:msvcproductid} = "unknown"
+      if (Test-Path "C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe") {
+        ${env:msvcversion}   = $(& "C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe" -latest -property catalog_productLineVersion)
+        ${env:msvcproductid} = $(& "C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe" -latest -property productId)
+      }
+      if([int]"${env:msvcversion}" -ge 2019) {
+        ${env:msvc_age} = "2019_or_younger"
+      } else {
+        ${env:msvc_age} = "2017_or_older"
+      }
+
+  # Make %x64% available for caching
+  # a variable used in the Appveyor cache area must be defined in the init
+  - ps: |
+      if ("$env:Platform" -eq "x64") {
+        $env:pf = "$env:ProgramFiles"
+        $env:x64 = "-x64"
+      } else {
+        $env:pf = "${env:ProgramFiles(x86)}"
+      }
+      $env:exe = "postgresql-$env:pg-windows$env:x64.exe"
+      [Environment]::SetEnvironmentVariable("exe", $env:exe, "Machine")
+
+      if ("${env:Platform}" -eq "x64") {
+        ${env:bit} = "64"
+      } else {
+        ${env:bit} = "32"
+      }
+      ${env:betterperl} = "strawberry${env:bit}"
+      ${env:betterperlurl} = "https://strawberryperl.com/download/5.32.1.1/strawberry-perl-5.32.1.1-${env:bit}bit-portable.zip"
+  #
+  # possible user provided in the matrix
+  #
+  - if not defined githubcache set githubcache=false
+  - if not defined pghint      set pghint=none
+  - if not defined  rlinkbinoldurl set  rlinkbinoldurl=none
+  - if not defined rversionurl set rversionurl=https://cran.r-project.org/bin/windows/base/old/%rversion%/R-%rversion%-win.exe
+  - if not defined rversion_more set rversion_more=-nodetails
+
+  install:
+  - echo compiler msvc install
+  #
+
+  - ps: |
+      # Set-PSDebug -Trace 2
+      # default
+      # special named R version(s)
+      if("${env:rlinkbinoldurl}" -eq "none") {
+        if("${env:rversion}" -match "beta|alpha|devel|patched") {
+          ${env:rversionurl} = "https://cran.r-project.org/bin/windows/base/R-${env:rversion}-win.exe"
+        }
+      } else {
+          # R general download (or a specific custom build)
+          ${env:rversionurl} = ${env:rlinkbinoldurl}
+      }
+      # .7z .zip .exe
+      ${env:rversionurl_download_ext} = [System.IO.Path]::GetExtension(${env:rversionurl})
+
+      # .7z .zip .exe # too many variants: not worth the time/code/headache/caching effort
+      if (Test-Path "R-${env:rversion}-win.exe") {
+        del         "R-${env:rversion}-win.exe"
+      }
+      #
+      # any download
+      # PowerShell 4.0, an Alias of "curl"
+      if(-not ("${env:rversionurl_download_ext}" -eq ".exe")) {
+        curl -o "R-${env:rversion}-win${env:rversionurl_download_ext}" -v "${env:rversionurl}"
+        7z e    "R-${env:rversion}-win${env:rversionurl_download_ext}" "R-${env:rversion}-win.exe"
+      } else {
+        curl -o "R-${env:rversion}-win.exe" -v "${env:rversionurl}"
+      }
+  #
+  - R-%rversion%-win.exe /VERYSILENT
+  #
+
+  - set mingw=C:\msys64\mingw
+  #
+  # From the EnterpriseDB version name,
+  # if any, strip off the: right-most part dot, then numbers, then one hyphen, then numbers.
+  - ps: $env:pgversion = $env:pg -replace "[.]\d+-\d+$", ""
+  #
+  - echo pgversion=%pgversion%
+  - set pgroot=%pf%\PostgreSQL\%pgversion%
+  - echo %pgroot%
+  #
+  # In the Perl x86 case, in Perl, in install.pl,  "mkdir" silently fails.
+  # %pgroot% is always needed (to use\place binaries in) to do the regression tests,
+  # so just, explicitly (early), create that directory here now.
+  #
+  - if not exist "%pgroot%" mkdir "%pgroot%"
+  - echo SHOWING pgroot - "%pgroot%"
+  - dir "%pgroot%"
+  #
+  - SET R_HOME=%ProgramFiles%\R\R-%rversion%
+  - set rbin=%Platform:x86=i386%
+
+  - SET sed=C:\msys64\usr\bin\sed
+
+  # Appveyor specific: seems not required - with Appveyor - Strawberry perl is already in the path
+  # ActiveState Perl is good, but Strawberry Perl is preferred
+  #
+  - ps: |
+      # Set-PSDebug -Trace 2
+      if (-not (Test-Path "${env:betterperl}.zip")) {
+        curl -o "${env:betterperl}.zip" -v "${env:betterperlurl}"
+      }
+      7z x    "${env:betterperl}.zip" "-oc:\${env:betterperl}"
+      # of needed to install pl/perl
+      ${env:PATH} = "c:\${env:betterperl}\perl\bin;${env:PATH}"
+      which perl
+      ${env:PATH} = "${env:PATH};c:\${env:betterperl}\c\bin"
+      which pexports
+
+  #
+  # if "githubcache: true",
+  #   then use the git tag 0.0.0.0.0.GITHUBCACHE in github as a "cache" of
+  #   pg already-compiled-binaries.
+  #
+  - set pg7z=pg-pg%pgversion%-%Platform%-%Configuration%-%compiler%.7z
+  - set pggithubbincacheurl=https://github.com/AndreMikulec/plr/releases/download/0.0.0.0.0.GITHUBCACHE/%pg7z%
+  #
+  # note: using Windows instead of Powershell
+  # I could not get the Invoke-??? . . . I would silently run (and die), I would not get error feedback.
+  #
+  - if "%githubcache%"=="true" if not exist "%pg7z%"  (
+      bash --login -c "$(cygpath ${APPVEYOR_BUILD_FOLDER})/pggithubbincachefailingfound.sh" &
+      for /f "delims=" %%i in (%APPVEYOR_BUILD_FOLDER%\pggithubbincachefailingfound.txt) do (set pggithubbincachefailingfound=%%i)
+    )
+  - if "%githubcache%"=="true" if "%pggithubbincachefailingfound%"=="false" curl -o "%pg7z%" -L "%pggithubbincacheurl%"
+  - if "%githubcache%"=="true" if "%pggithubbincachefailingfound%"=="false" if exist "%pg7z%" (set pggithubbincachefound=true) else (set pggithubbincachefound=false)
+  - if "%githubcache%"=="true" if "%pggithubbincachefailingfound%"=="false" if "%pggithubbincachefound%"=="true" (
+        mkdir            "%pgroot%" &
+        7z x "%pg7z%"  "-o%pgroot%" &
+        dir              "%pgroot%" &
+        if exist "%pgroot%\bin\postgres.exe" (set pggithubbincacheextracted=true) else (set pggithubbincacheextracted=false)
+    )
+  # user provided (if any), in the matrix
+  - echo githubcache %githubcache%
+  # generated
+  # internal - do not reuse
+  - echo pggithubbincachefailingfound %pggithubbincachefailingfound%
+  # reused below
+  - echo pggithubbincachefound %pggithubbincachefound%
+  - if not defined pggithubbincachefound set pggithubbincachefound=false
+  - echo pggithubbincachefound %pggithubbincachefound%
+  # reused below
+  - echo pggithubbincacheextracted %pggithubbincacheextracted%
+  - if not defined pggithubbincacheextracted set pggithubbincacheextracted=false
+  - echo pggithubbincacheextracted %pggithubbincacheextracted%
+
+  #
+  # Remove old plr files, from the pg already-compiled-binary
+  # extraction from 0.0.0.0.0.GITHUBCACHE, if any old files
+  #
+  - ps: |
+      # Set-PSDebug -Trace 2
+      if (("${env:githubcache}" -eq "true") -and ("${env:pggithubbincacheextracted}" -eq "true")) {
+        pushd "${env:pgroot}"
+        del share\extension\plr--*.sql   2>null
+        del share\extension\plr.control  2>null
+        del lib\plr.dll                  2>null
+        del symbols\plr.pdb              2>null
+        popd
+      }
+
+  #
+  # msbuild needs
+  #
+  - ps: |
+      # Set-PSDebug -Trace 2
+      if (("$env:githubcache" -eq "true") -and ("$env:pggithubbincacheextracted" -eq "true")) {
+        $env:proj="plr.vcxproj"
+        $env:dll="$($env:Platform.replace('x86', '.'))\$env:Configuration\plr.dll"
+      }
+
+
+  - ps: |
+      # "branchtagcommit" exists only because, this makes an easier test in a windows batch
+      # This environment variable is use in a test that is used that is used in determining
+      # whether or not to perform patching (see below).
+      #
+      if ("${env:pg}" -notmatch "[.]") {
+        ${env:branchtagcommit} = "yes"
+      } else {
+        ${env:branchtagcommit} = "no"
+      }
+      echo "branchtagcommit ${env:branchtagcommit}"
+
+
+  #
+  # PostgreSQL from source code: git, tag, or commit
+  #
+  - ps: |
+      # Set-PSDebug -Trace 2
+      # notmatch - if no "dot is found" in pg name, then pg is a: git: branch, tag, or commit.
+      if (("${env:pggithubbincacheextracted}" -eq "false") -and ("${env:pg}" -notmatch "[.]")) {
+        git config --global advice.detachedHead false
+        $env:PATH += ";C:\msys64\usr\bin;C:\msys64\mingw64\bin;C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\bin\amd64"
+        #
+        # git branch or commit - alphanumeric and all lowercase letters (slower download)
+        #
+        if(("${env:pg}" -cmatch  "^[a-z0-9]+$") -and ("${env:pghint}" -eq "commit")) {
+          git clone -q                            https://git.postgresql.org/git/postgresql.git c:\projects\postgresql
+          pwd
+          pushd c:\projects\postgresql
+          pwd
+          git checkout -q                 ${env:pg} -b ${env:pg}
+          git branch
+          echo ${env:pg}
+          popd
+          pwd
+        #
+        # git branch or tag(detached head)
+        # PostgreSQL case - git branches and tags have at least one capital letter - but expect mostly CAPS
+        #
+        } else {
+          git clone -q --depth 1 --branch ${env:pg} https://git.postgresql.org/git/postgresql.git c:\projects\postgresql
+          pushd c:\projects\postgresql
+          pwd
+          git branch
+          echo ${env:pg}
+          popd
+          pwd
+        }
+        pushd c:\projects\postgresql
+        pwd
+        echo "Files . . ."
+        $Table = Get-ChildItem
+        foreach ($Row in $Table) { $Row.Name }
+        popd
+      }
+
+  #
+  # PostgreSQL from source code: git, tag, or commit
+  #
+  # dynamically patch, so that a separate msvc.diff file does not have to be used
+  #
+  # Required "postgresrcroot" for msvc.diff.R and Solution.pm.R
+  - set postgresrcroot=C:\projects\postgresql
+  #
+  - if "%pggithubbincacheextracted%"=="false" if "%branchtagcommit%"=="yes" (
+        echo Begin performing patching on-the-fly &
+        pushd "C:\projects\postgresql" &
+        copy "src\tools\msvc\Mkvcbuild.pm" "src\tools\msvc\Mkvcbuild.pm.old" &
+        copy "src\tools\msvc\vcregress.pl" "src\tools\msvc\vcregress.pl.old" &
+        popd &
+        echo Begin patching &
+        echo "%R_HOME%\bin\%rbin%\Rscript.exe" --vanilla %APPVEYOR_BUILD_FOLDER%\msvc.diff.R &
+             "%R_HOME%\bin\%rbin%\Rscript.exe" --vanilla %APPVEYOR_BUILD_FOLDER%\msvc.diff.R &
+        echo End patching &
+        pushd "C:\projects\postgresql" &
+        git diff --no-index "src/tools/msvc/Mkvcbuild.pm.old" "src/tools/msvc/Mkvcbuild.pm" --output=%APPVEYOR_BUILD_FOLDER%\Mkvcbuild.pm.diff &
+        sed -i "s/Mkvcbuild.pm.old/Mkvcbuild.pm/g" %APPVEYOR_BUILD_FOLDER%\Mkvcbuild.pm.diff &
+        git diff --no-index "src/tools/msvc/vcregress.pl.old" "src/tools/msvc/vcregress.pl" --output=%APPVEYOR_BUILD_FOLDER%\vcregress.pl.diff &
+        sed -i "s/vcregress.pl.old/vcregress.pl/g" %APPVEYOR_BUILD_FOLDER%\vcregress.pl.diff &
+        popd &
+        type %APPVEYOR_BUILD_FOLDER%\Mkvcbuild.pm.diff %APPVEYOR_BUILD_FOLDER%\vcregress.pl.diff > %APPVEYOR_BUILD_FOLDER%\msvc.diff &
+        echo **** Begin Display %APPVEYOR_BUILD_FOLDER%\msvc.diff **** &
+             type          %APPVEYOR_BUILD_FOLDER%\msvc.diff &
+        echo **** End   Display %APPVEYOR_BUILD_FOLDER%\msvc.diff **** &
+        echo Begin display of Mkvcbuild.pm &
+        type c:\projects\postgresql\src\tools\msvc\Mkvcbuild.pm &
+        echo End display of Mkvcbuild.pm &
+        echo Begin display of vcregress.pl &
+        type c:\projects\postgresql\src\tools\msvc\vcregress.pl &
+        echo End display of vcregress.pl &
+        echo End performing patching on-the-fly
+    )
+
+
+  #
+  # PostgreSQL from source code: git, tag, or commit
+  #
+  # Microsoft Visual Studio specific: "cl /?" or "cl /help" can not be ran.
+  # "cl" is interpreted as an Appveyor specific alias to the Windows command "call"
+  # so PostgreSQL, can not correctly determing the platform.
+  #
+  # Trying to override the phantom alias executable "cl" - Microsoft "call"
+  # https://help.appveyor.com/discussions/problems/29255-trying-to-override-the-phantom-alias-executable-cl-microsoft-call
+  #
+  # force x86 to have the CPlatform: Win32
+  # force x64 to have the CPlatform: x64
+  #
+  - if "%pggithubbincacheextracted%"=="false" if "%branchtagcommit%"=="yes" (
+      echo Begin performing patching on-the-fly &
+      echo Begin patching
+    )
+  - if "%pggithubbincacheextracted%"=="false" if "%branchtagcommit%"=="yes" if "%Platform%"=="x86" (
+        echo "%R_HOME%\bin\%rbin%\Rscript.exe" --vanilla %APPVEYOR_BUILD_FOLDER%\Solution.pm.R Win32 &
+             "%R_HOME%\bin\%rbin%\Rscript.exe" --vanilla %APPVEYOR_BUILD_FOLDER%\Solution.pm.R Win32
+    )
+  - if "%pggithubbincacheextracted%"=="false" if "%branchtagcommit%"=="yes" if "%Platform%"=="x64" (
+        echo "%R_HOME%\bin\%rbin%\Rscript.exe" --vanilla %APPVEYOR_BUILD_FOLDER%\Solution.pm.R x64 &
+             "%R_HOME%\bin\%rbin%\Rscript.exe" --vanilla %APPVEYOR_BUILD_FOLDER%\Solution.pm.R x64
+    )
+  - if "%pggithubbincacheextracted%"=="false" if "%branchtagcommit%"=="yes" (
+      echo End patching &
+      echo Begin display of Solution.pm &
+      type c:\projects\postgresql\src\tools\msvc\Solution.pm &
+      echo End display of Solution.pm &
+      echo End performing patching on-the-fly
+    )
+
+  #
+  # PostgreSQL from source code: git, tag, or commit
+  #
+  - ps: |
+      # Set-PSDebug -Trace 2
+      if (("$env:pggithubbincacheextracted" -eq "false") -and ("$env:pg" -notmatch "[.]")) {
+        gendef - "$env:R_HOME\bin\$env:rbin\R.dll" > "R$env:Platform.def" 2> $null
+        lib "/def:R$env:Platform.def" "/out:R$env:Platform.lib" "/MACHINE:$env:Platform"
+        pwd
+        echo "Files . . ."
+        $Table = Get-ChildItem
+        foreach ($Row in $Table) { $Row.Name }
+        pushd c:\projects\postgresql
+        pwd
+        echo "Files . . ."
+        $Table = Get-ChildItem
+        foreach ($Row in $Table) { $Row.Name }
+        cmd /c mklink /J contrib\plr $env:APPVEYOR_BUILD_FOLDER
+        #
+        # patch already done - above - using msvc.diff.R
+        # patch -p1 -i "$env:APPVEYOR_BUILD_FOLDER\msvc.diff"
+        #
+        # creates both plr.vcxproj and pgsql.sln
+        perl contrib\plr\buildsetup.pl
+        pwd
+        echo "Files . . ."
+        $Table = Get-ChildItem
+        foreach ($Row in $Table) { $Row.Name }
+        type C:\projects\postgresql\pgsql.sln
+        type plr.vcxproj
+        # echo . . . COMPARING . . .
+        # type pgcrypto.vcxproj
+        # type postgres.vcxproj
+        popd
+        pwd
+        echo "Files . . ."
+        $Table = Get-ChildItem
+        foreach ($Row in $Table) { $Row.Name }
+        $env:proj="C:\projects\postgresql\pgsql.sln"
+        $env:dll="c:\projects\postgresql\$env:Configuration\plr\plr.dll"
+      }
+
+  # Remove the semi-duplicate "plr" entry int the pgsql.sln file.
+  # This is needed for msvc versions 2019 and later.
+  # On msvc 2017 and older versions this duplicate entry is required.
+  - if exist C:\projects\postgresql\pgsql.sln if "%branchtagcommit%"=="yes" if "%msvc_age%"=="2019_or_younger" (
+      echo REMOVE plr ENTRY from pgsql.sln &
+      echo FILE BEFORE clean_pgsql_sln.sh C:\projects\postgresql\pgsql.sln &
+      type      C:\projects\postgresql\pgsql.sln &
+      bash -lc '/c/projects/plr/clean_pgsql_sln.sh' &
+      echo FILE AFTER clean_pgsql_sln.sh C:\projects\postgresql\pgsql.sln &
+      type      C:\projects\postgresql\pgsql.sln
+    )
+
+  # PostgreSQL from Appveyor or an EnterpriseDB already-compiled-binary.
+  - ps: |
+      # Set-PSDebug -Trace 2
+      if (("$env:pggithubbincacheextracted" -eq "false") -and ("$env:pg" -match "[.]")) {
+        $env:proj="plr.vcxproj"
+        $env:dll="$($env:Platform.replace('x86', '.'))\$env:Configuration\plr.dll"
+        if (-not (Test-Path "$env:pgroot\bin")) {
+          if (-not (Test-Path "$env:exe")) {
+            Start-FileDownload "http://get.EnterpriseDB.com/postgresql/$env:exe"
+          }
+          & ".\$env:exe" --unattendedmodeui none --mode unattended --superpassword "$env:PGPASSWORD" --servicepassword "$env:PGPASSWORD" | Out-Null
+          Stop-Service "postgresql$env:x64-$env:pgversion"
+          if ( Test-Path "$env:pgroot\bin" ) {
+            echo  "Directory $env:pgroot\bin does exist. - software from EnterpriseDB (https://www.enterprisedb.com/downloads/postgres-postgresql-downloads)."
+            echo "$env:pgroot"
+            echo "Files . . ."
+            $Table = Get-ChildItem "$env:pgroot"
+            foreach ($Row in $Table) { $Row.Name }
+          } else {
+            throw "Directory $env:pgroot\bin does not exist.`r`nDoes EnterpriseDB (https://www.enterprisedb.com/downloads/postgres-postgresql-downloads) have that version/platform combination?"
+          }
+        }
+        if ( Test-Path "$env:pgroot\bin" ) {
+          echo  "Directory $env:pgroot\bin does exist. - solution from appveyor (https://www.appveyor.com/docs/services-databases/#postgresql) or EnterpriseDB (https://www.enterprisedb.com/downloads/postgres-postgresql-downloads)."
+          echo "$env:pgroot"
+          echo "Files . . ."
+          $Table = Get-ChildItem "$env:pgroot"
+          foreach ($Row in $Table) { $Row.Name }
+        } else {
+          throw "Neither appveyor (https://www.appveyor.com/docs/services-databases/#postgresql) nor EnterpriseDB (https://www.enterprisedb.com/downloads/postgres-postgresql-downloads) have that version/platform combination?"
+        }
+      }
+
+  # msbuild: reads the environment variable Platform. The Platform value can be either Win32 xor x64.
+  # xor
+  # msbuild: can read /p:platform=Value. The Value can be either Win32 xor x64.
+  #
+  build_script:
+  - echo compiler msvc build_script
+  - if %Platform%==x86 set CPlatform=Win32
+  - if %Platform%==x64 set CPlatform=x64
+  #
+  # note: build.pl is an alternative
+  #
+  - REM verbosity levels: q[uiet], m[inimal](orig program), n[ormal] (default), d[etailed], and diag[nostic]
+  - msbuild /p:PlatformToolset=%PlatformToolset% /p:configuration=%Configuration% /p:platform=%CPlatform%
+            %proj%
+            /verbosity:quiet /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
+
+
+  after_build:
+  - appveyor AddMessage Packing -Category Information
+  - md tmp\share\extension
+  - dir .
+  - copy *.sql tmp\share\extension\
+  - copy *.control tmp\share\extension\
+  - copy LICENSE tmp\PLR_LICENSE
+  - md tmp\lib
+  - md tmp\symbols
+  - copy %dll% tmp\lib
+  - copy %dll:.dll=.pdb% tmp\symbols
+  - dir tmp
+  - set var7z=plr-%APPVEYOR_REPO_COMMIT:~0,8%-pg%pgversion%-R%rversion%%rversion_more%-%Platform%-%Configuration%-%compiler%.7z
+  - 7z a -t7z -mmt24 -mx7 -r %var7z% .\tmp\* > nul
+  - dir "%var7z%"
+  - echo appveyor PushArtifact "%var7z%"
+  -      appveyor PushArtifact "%var7z%"
+
+  #
+  # place files from the .\Debug or .\Release directories onto $env:pgroot
+  #
+  - ps: |
+      # Set-PSDebug -Trace 2
+      if (("$env:pggithubbincacheextracted" -eq "false") -and ("$env:pg" -notmatch "[.]")) {
+        pushd c:\projects\postgresql\src\tools\msvc
+        pwd
+        echo "Files . . ."
+        $Table = Get-ChildItem
+        foreach ($Row in $Table) { $Row.Name }
+        perl install.pl "$env:pgroot"
+        pwd
+        echo "Files . . ."
+        $Table = Get-ChildItem
+        foreach ($Row in $Table) { $Row.Name }
+        popd
+        pwd
+      }
+  #
+  # #
+  # - echo BEGIN TRY TO FIND INSTALLED FILES LOCATION: postgres.exe and plr.dll
+  - bash --login -c "find \"$(cygpath \"${pf}\")\" -name '*postgres.exe' -type f 2>/dev/null"
+  - bash --login -c "find \"$(cygpath \"${pf}\")\" -name '*plr.dll'      -type f 2>/dev/null"
+  # - echo END TRY TO FIND INSTALLED FILES LOCATION: postgres.exe and plr.dll
+  # #
+
+  #
+  # same as above (repeated here)
+  - set pg7z=pg-pg%pgversion%-%Platform%-%Configuration%-%compiler%.7z
+  #
+  # Zipping must be performed here, after "perl install.pl".
+  # pg has been installed inside %pgroot% == %pf%\PostgreSQL\%pgversion% (see above).
+  # The PostgreSQL cluster must be down.
+  # The environment variable "pggithubbincachefound" is
+  #   used in determining whether or not to attempt to
+  #   deploy to the Github release 0.0.0.0.0.GITHUBCACHE (see below).
+  #
+  # "%pgroot%\bin\postgres.exe" SHOULD BE THERE - missing should NOT happen
+  - if "%githubcache%"=="true" if "%pggithubbincachefound%"=="false" if exist "%pgroot%\bin\postgres.exe" (
+      7z a -t7z -mmt24 -mx7 -r "%pg7z%"  "%pgroot%\*" > nul
+    )
+  #
+  # Often push "msvc pg" artifacts (because they are not too big.)
+  #
+  - if "%githubcache%"=="true" if "%pggithubbincachefound%"=="false" if exist "%pgroot%\bin\postgres.exe" if exist "%pg7z%" (
+      appveyor PushArtifact "%pg7z%"
+    )
+  # what did I 7z up?
+  - ps: |
+      # Set-PSDebug -Trace 2
+      if ( ("$env:githubcache" -eq "true") -and ("$env:pggithubbincachefound" -eq "false") -and (Test-Path "$env:pgroot\bin\postgres.exe") ) {
+        7z l "$env:pg7z"
+      }
+
+  test_script:
+  - echo compiler msvc test_script
+  - path %pgroot%\bin;%PATH%
+  - which postgres
+  # From source code, but at this point in time,
+  # the source code is an already (compiled) binary on disk and correctly located within $env:pgroot.
+  #   see above - perl install.pl
+  - ps: |
+      # Set-PSDebug -Trace 2
+      if ("$env:pg" -notmatch "[.]") {
+        Set-Content -path pg.pass -value "$env:pgpassword" -encoding ascii
+        initdb -A md5 -U "$env:PGUSER" --pwfile=pg.pass C:\pgdata
+        pg_ctl register -S demand -N "postgresql$env:x64-$env:pgversion" -D c:\pgdata
+      } else {
+        Add-AppveyorMessage "Copying the extension files to the PostgreSQL directories." -Category Information
+        7z x "$env:var7z" "-o$env:pgroot"
+      }
+      #
+      # If the pg is from the already-compiled-binary 0.0.0.0.0.GITHUBCACHE,
+      # then, add the "plr" to be (eventually) regression tested.
+      #
+      if (("$env:githubcache" -eq "true") -and ("$env:pggithubbincacheextracted" -eq "true")) {
+        7z x "$env:var7z" "-o$env:pgroot"
+      }
+
+  - appveyor AddMessage "Starting the database server." -Category Information
+  - setx /M PATH "%R_HOME%\bin\%rbin%;%PATH%"
+  - net start postgresql%x64%-%pgversion%
+  #
+  # I need the server_version_num, so we can later, test to determine "$env:psqlopt".
+  # I can not use "$env:pgversion" because a branch, tag, or commit
+  # name (e.g.) "master" can not (always) be (easily) compared.
+  #
+  # R 4.2.+ (on Windows utf8) sanity check
+  - psql -c "\l template[01]"
+  #
+  # also used in compiler - msys2 and cygwin
+  - psql --quiet --tuples-only -c "\pset footer off" -c "\timing off" -c "select current_setting('server_version_num')::integer;" --output=%APPVEYOR_BUILD_FOLDER%\server_version_num.txt
+  - bash --login -c "$(cygpath ${APPVEYOR_BUILD_FOLDER})/server_version_num.sh"
+  # load new environment variable(s) e.g. "server_version_num" into the current Windows
+  - for /f "delims=" %%i in (%APPVEYOR_BUILD_FOLDER%\server_version_num.txt) do (set server_version_num=%%i)
+  - type %APPVEYOR_BUILD_FOLDER%\server_version_num.txt
+  - echo server_version_num %server_version_num%
+  - ps: |
+      # Set-PSDebug -Trace 2
+      Add-AppveyorTest Regression -Framework pg_regress -FileName sql\ -Outcome Running
+      # less than pg 9.5
+      if ([double]"$env:server_version_num" -lt 90500.0) {
+        $env:psqlopt="--psqldir"
+      } else {
+        $env:psqlopt="--bindir"
+      }
+      $env:Outcome="Passed"
+      $elapsed=(Measure-Command {
+        pg_regress "$env:psqlopt=$env:pgroot\bin" --dbname=pl_regression plr `
+          bad_fun opt_window do out_args plr_transaction opt_window_frame 2>&1 |
+          %{ if ($_ -is [System.Management.Automation.ErrorRecord]) { $_.Exception.Message } else { $_ } } |
+            Out-Default
+        if ($LASTEXITCODE -ne 0) {
+          $env:Outcome="Failed"
+        }
+      }).TotalMilliseconds
+      Update-AppVeyorTest Regression -Framework pg_regress -FileName sql\ -Outcome "$env:Outcome" -Duration $elapsed
+      if ("$env:Outcome" -ne "Passed") {
+        type regression.diffs
+        $host.SetShouldExit($LastExitCode)
+      }
 
 
 #on_failure:
 # - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
 
 cache:
+# PostgreSQL
 - '%exe%'
-- R-%rversion%-win.exe
+# I think that I have the space
 - '%betterperl%.zip'
 
-build_script:
-- msbuild /p:PlatformToolset=%PlatformToolset% /p:configuration=%CONFIGURATION% /p:platform=%PLATFORM%
-          %PROJ%
-          /verbosity:minimal /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
-
-after_build:
-- appveyor AddMessage Packing -Category Information
-- md tmp\share\extension
-- copy *.sql tmp\share\extension\
-- copy *.control tmp\share\extension\
-- copy LICENSE tmp\PLR_LICENSE
-- md tmp\lib
-- md tmp\symbols
-- copy %dll% tmp\lib
-- copy %dll:.dll=.pdb% tmp\symbols
-- set zip=plr-%APPVEYOR_REPO_COMMIT:~0,8%-pg%pgversion%-R%rversion%-%PLATFORM%-%CONFIGURATION%.zip
-- 7z a -r %zip% .\tmp\* > nul
-- ps: |
-    if ("$env:pg" -notmatch "[.]") {
-      pushd c:\projects\postgresql\src\tools\msvc
-      perl install.pl "$env:pgroot"
-      popd
-    }
-
-test_script:
-- path %pgroot%\bin;%PATH%
-- ps: |
-    if ("${env:branchtagcommit}" -eq "yes") {
-      Set-Content -path pg.pass -value "$env:pgpassword" -encoding ascii
-      initdb -A md5 -U "$env:PGUSER" --pwfile=pg.pass C:\pgdata
-      pg_ctl register -S demand -N "postgresql$env:x64-$env:pgversion" -D c:\pgdata
-    } else {
-      Add-AppveyorMessage "Copying the extension files to the PostgreSQL directories." -Category Information
-      7z x "$env:zip" "-o$env:pgroot"
-    }
-- appveyor AddMessage "Starting the database server." -Category Information
-- setx /M PATH "%R_HOME%\bin\%rbin%;%PATH%"
-- net start postgresql%x64%-%pgversion%
-
-- ps: |
-    Add-AppveyorTest Regression -Framework pg_regress -FileName sql\ -Outcome Running
-    if (("9.3", "9.4").Contains("$env:pgversion")) {
-      $env:psqlopt="--psqldir"
-    } else {
-      $env:psqlopt="--bindir"
-    }
-    $env:Outcome="Passed"
-    $elapsed=(Measure-Command {
-      pg_regress "$env:psqlopt=$env:pgroot\bin" --dbname=pl_regression plr `
-        bad_fun opt_window do out_args plr_transaction opt_window_frame 2>&1 |
-        %{ if ($_ -is [System.Management.Automation.ErrorRecord]) { $_.Exception.Message } else { $_ } } |
-          Out-Default
-      if ($LASTEXITCODE -ne 0) {
-        $env:Outcome="Failed"
-      }
-    }).TotalMilliseconds
-    Update-AppVeyorTest Regression -Framework pg_regress -FileName sql\ -Outcome "$env:Outcome" -Duration $elapsed
-    if ("$env:Outcome" -ne "Passed") {
-      type regression.diffs
-      $host.SetShouldExit($LastExitCode)
-    }
-
 artifacts:
-- path: 'plr*.zip'
+- path: 'plr-*.7z'
+  name: plr_7z
+- path: 'pg-*.7z'
+  name: pg_7z
 
 deploy:
-   provider: GitHub
-   release: $(appveyor_repo_tag_name)
-   draft: false
-   prerelease: false
-   auth_token:
+
+#   # If the "release" does not pre-exist and thus "secure" will try to create the release
+#   # and if "secure" does not have permission to create a release, then an ERROR will occur,
+#   # then Appveyor will ERROR.
+#   - provider: GitHub
+#     release: 0.0.0.0.0.GITHUBCACHE
+#     draft: false
+#     prerelease: false
+#     artifact: pg_7z
+#     auth_token:
+#       secure: DpxrjrmF0pQsm3G/F8m7EDVz6yhBQhlwXWOtqxgQTmUMiofL1PZD+9Q1dAqyKh9Z
+#     # non - "branch, tag, or commit" will still be expected "false" ( githubcache != true )
+#     # and never find a pg-*.7z to deploy - and that is OK.
+
+  #
+  # last of Github deployments, to try to appear as "latest"
+  #
+  - provider: GitHub
+    release: $(APPVEYOR_REPO_TAG_NAME)
+    draft: false
+    prerelease: false
+    artifact: plr_7z
+    auth_token:
       secure: DpxrjrmF0pQsm3G/F8m7EDVz6yhBQhlwXWOtqxgQTmUMiofL1PZD+9Q1dAqyKh9Z
-   on:
-      appveyor_repo_tag: true
+    on:
+      APPVEYOR_REPO_TAG: true
 

--- a/build_script.sh
+++ b/build_script.sh
@@ -1,0 +1,283 @@
+
+cd "$(dirname "$0")"
+
+. ./init.sh
+
+logok "BEGIN build_script.sh"
+
+set -v -x -e
+# set -e
+
+# which R msys2 and cygwin
+# /c/RINSTALL/bin/x64/R
+# /usr/bin/R
+loginfo "which R $(which R)"
+
+# just needed for the "make"
+#
+# so perl can use better regular expressions
+export PATH=$(echo $(cygpath "c:\\${betterperl}\perl\bin")):${PATH}
+#
+# also, so I need "pexports", that is needed when,
+# I try to use "postresql source code from git" to build postgres
+# ("pexports" is not needed when I use the "downloadable postgrsql" source code)
+export PATH=${PATH}:$(echo $(cygpath "c:\\${betterperl}\c\bin"))
+
+
+if [ "${pggithubbincacheextracted}" == "false" ] && [ ! "${pg}" == "none" ]
+then
+  loginfo "BEGIN PostgreSQL EXTRACT XOR CONFIGURE+BUILD+INSTALL"
+  if [ ! -f "pg-pg${pgversion}-${Platform}-${Configuration}-${compiler}.7z" ]
+  then
+    loginfo "BEGIN PostgreSQL CONFIGURE"
+    cd ${pgsource}
+    if [ "${Configuration}" == "Release" ]
+    then
+      ./configure --enable-depend --disable-rpath --without-icu --prefix=${pgroot}
+    fi
+    if [ "${Configuration}" == "Debug" ]
+    then
+      ./configure --enable-depend --disable-rpath --without-icu --enable-debug --enable-cassert CFLAGS="-ggdb -Og -g3 -fno-omit-frame-pointer" --prefix=${pgroot}
+    fi
+    loginfo "END   PostgreSQL CONFIGURE"
+    loginfo "BEGIN PostgreSQL BUILD"
+    make
+    loginfo "END   PostgreSQL BUILD"
+    loginfo "BEGIN PostgreSQL INSTALL"
+    make install
+    loginfo "END   PostgreSQL INSTALL"
+    cd ${APPVEYOR_BUILD_FOLDER}
+    loginfo "END   PostgreSQL BUILD + INSTALL"
+  else
+    loginfo "BEGIN 7z EXTRACTION"
+    cd ${pgroot}
+    7z l "${APPVEYOR_BUILD_FOLDER}/pg-pg${pgversion}-${Platform}-${Configuration}-${compiler}.7z"
+    7z x "${APPVEYOR_BUILD_FOLDER}/pg-pg${pgversion}-${Platform}-${Configuration}-${compiler}.7z"
+    ls -alrt ${pgroot}
+    cd ${APPVEYOR_BUILD_FOLDER}
+    loginfo "END   7z EXTRACTION"
+  fi
+  loginfo "END   PostgreSQL EXTRACT XOR CONFIGURE+BUILD+INSTALL"
+fi
+
+
+# put this in all non-init.sh scripts - pgroot is empty, if using an msys2 binary
+# but psql is already in the path
+if [ -f "${pgroot}/bin/psql" ]
+then
+  export PATH=${pgroot}/bin:${PATH}
+fi
+#
+# cygwin # pgroot: /usr - is the general location of binaries (psql) and already in the PATH
+#
+# $ echo $(cygpath "C:\cygwin\bin")
+# /usr/bin
+#
+# cygwin # initdb, postgres, and pg_ctl are here "/usr/sbin"
+if [ -f "${pgroot}/sbin/postgres" ]
+then
+  export PATH=${pgroot}/sbin:${PATH}
+fi
+
+# # Later I get this information from pgconfig variables PKGLIBDIR SHAREDIR.
+# # Therefore, I do not need this variable "dirpostgresql" anymore.
+# 
+# # helps determine where to extract the plr files . .
+# #
+# # Uses the "/postgresql" directory if the plr files are found in the
+# # default cygwin-package-management shared install folders
+# #
+# if [ -d "${pgroot}/share/postgresql" ]
+# then
+#   export dirpostgresql=/postgresql
+# fi
+
+# build from source
+# psql: error: could not connect to server: FATAL:  role "appveyor" does not exist
+# psql: error: could not connect to server: FATAL:  database "appveyor" does not exist
+#
+
+# # loginfo "BEGIN MY ENV VARIABLES"
+# export
+# # loginfo "END MY ENV VARIABLES"
+# 
+loginfo "BEGIN verify that PLR will link to the correct PostgreSQL"
+loginfo "which psql : $(which psql)"
+loginfo "which pg_ctl: $(which pg_ctl)"
+loginfo "which initdb: $(which initdb)"
+loginfo "which postgres: $(which postgres)"
+loginfo "which pg_config: $(which pg_config)"
+logok   "pg_config . . ."
+pg_config
+loginfo "END   verify that PLR will link to the correct PostgreSQL"
+# 
+# ls -alrt /usr/sbin
+# ls -alrt ${pgroot}/sbin
+# which postgres
+
+#
+# PostgreSQL on msys2 (maybe also cygwin?) does not use(read) PG* variables [always] [correctly] (strange!)
+# so, e.g. in psql, I do not rely on environment variables
+
+# build from source
+# psql: error: could not connect to server: FATAL:  role "appveyor" does not exist
+# psql: error: could not connect to server: FATAL:  database "appveyor" does not exist
+#
+
+if [ "${compiler}" == "msys2" ]
+then
+  winpty -Xallow-non-tty initdb --pgdata="${PGDATA}" --auth=trust --encoding=utf8 --locale=C
+else
+                         initdb --pgdata="${PGDATA}" --auth=trust --encoding=utf8 --locale=C
+fi
+
+# Success. You can now start the database server using:
+# C:/msys64/mingw64/bin/pg_ctl -D C:/msys64//home/appveyor/mingw64/postgresql/Data -l logfile start
+# C:/msys64/mingw64/bin/pg_ctl -D ${PGDATA} -l logfile start
+
+# first
+pg_ctl -D ${PGDATA} -l logfile start
+pg_ctl -D ${PGDATA} -l logfile stop
+
+# do again
+pg_ctl -D ${PGDATA} -l logfile start
+pg_ctl -D ${PGDATA} -l logfile stop
+
+# leave it up
+pg_ctl -D ${PGDATA} -l logfile start
+
+if [ "${compiler}" == "msys2" ]
+then
+  winpty -Xallow-non-tty psql -d postgres -c 'SELECT version();'
+else
+                         psql -d postgres -c 'SELECT version();'
+fi
+
+pg_ctl -D ${PGDATA} -l logfile stop
+
+
+
+
+#
+# not yet tried/tested in cygwin
+#                                                                                                                           # cygwin case
+if [ "${githubcache}" == "true" ] && [ "${pggithubbincachefound}" == "false" ] && ([ -f "${pgroot}/bin/postgres" ] || [ -f "${pgroot}/sbin/postgres" ])
+then
+  loginfo "BEGIN pg 7z CREATION"
+  cd ${pgroot}
+  ls -alrt
+  loginfo                                            "pg-pg${pgversion}-${Platform}-${Configuration}-${compiler}.7z"
+  7z a -t7z -mmt24 -mx7 -r   ${APPVEYOR_BUILD_FOLDER}/pg-pg${pgversion}-${Platform}-${Configuration}-${compiler}.7z *
+  7z l                       ${APPVEYOR_BUILD_FOLDER}/pg-pg${pgversion}-${Platform}-${Configuration}-${compiler}.7z
+  ls -alrt                   ${APPVEYOR_BUILD_FOLDER}/pg-pg${pgversion}-${Platform}-${Configuration}-${compiler}.7z
+  export  pg_7z_size=$(find "${APPVEYOR_BUILD_FOLDER}/pg-pg${pgversion}-${Platform}-${Configuration}-${compiler}.7z" -printf "%s")
+  loginfo "pg_7z_size $pg_7z_size" 
+  #                       96m
+  if [ ${pg_7z_size} -gt 100663296 ] 
+  then
+    rm -f    ${APPVEYOR_BUILD_FOLDER}/pg-pg${pgversion}-${Platform}-${Configuration}-${compiler}.7z
+    loginfo "${APPVEYOR_BUILD_FOLDER}/pg-pg${pgversion}-${Platform}-${Configuration}-${compiler}.7z is TOO BIG so removed."
+  fi
+  #
+  if [ -f "${APPVEYOR_BUILD_FOLDER}/pg-pg${pgversion}-${Platform}-${Configuration}-${compiler}.7z" ]
+  then
+    if [ "${compiler}" == "cygwin" ]
+    then
+      # workaround of an Appveyor-using-cygwin bug - command will automatically pre-prepend A DIRECTORY (strange!)
+      # e.g.
+      pushd ${APPVEYOR_BUILD_FOLDER}
+      #
+      # NOTE FTP Deploy will automatically PushArtifact, so I will not do that HERE.
+      #
+      # loginfo "appveyor PushArtifact                          pg-pg${pgversion}-${Platform}-${Configuration}-${compiler}.7z"
+      #          appveyor PushArtifact                          pg-pg${pgversion}-${Platform}-${Configuration}-${compiler}.7z
+      popd
+  # bash if-then-else-fi # inside bodies can not be empty
+  # else
+      #
+      # NOTE FTP Deploy will automatically PushArtifact, so I will not do that HERE.
+      #
+      # loginfo "appveyor PushArtifact ${APPVEYOR_BUILD_FOLDER}/pg-pg${pgversion}-${Platform}-${Configuration}-${compiler}.7z"
+      #          appveyor PushArtifact ${APPVEYOR_BUILD_FOLDER}/pg-pg${pgversion}-${Platform}-${Configuration}-${compiler}.7z
+    fi
+  fi
+  #
+  cd ${APPVEYOR_BUILD_FOLDER} 
+  loginfo "END   pg 7z CREATION"
+fi
+
+# do again
+pg_ctl -D ${PGDATA} -l logfile start
+
+
+# -g3 because of the many macros
+#
+if [ "${Configuration}" = "Debug" ]
+then
+  echo ""                                                         >> Makefile
+  echo "override CFLAGS += -ggdb -Og -g3 -fno-omit-frame-pointer" >> Makefile
+  echo ""                                                         >> Makefile
+fi
+
+loginfo "BEGIN plr BUILDING"
+USE_PGXS=1 make
+loginfo "END   plr BUILDING"
+loginfo "BEGIN plr INSTALLING"
+USE_PGXS=1 make install
+loginfo "END   plr INSTALLING"
+
+if [ "${compiler}" == "msys2" ]
+then
+  winpty -Xallow-non-tty psql -d postgres -c 'CREATE EXTENSION plr;'
+else
+                         psql -d postgres -c 'CREATE EXTENSION plr;'
+fi
+
+if [ "${compiler}" == "msys2" ]
+then
+  winpty -Xallow-non-tty psql -d postgres -c 'SELECT plr_version();'
+else
+                         psql -d postgres -c 'SELECT plr_version();'
+fi
+
+# R 4.2.+ (on Windows utf8) sanity check
+if [ "${compiler}" == "msys2" ]
+then
+  winpty -Xallow-non-tty psql -d postgres -c '\l template[01]'
+else
+                         psql -d postgres -c '\l template[01]'
+fi
+
+# How to escape single quotes within single quoted strings
+# 2009 - MULTIPLE SOLUTIONS
+# https://stackoverflow.com/questions/1250079/how-to-escape-single-quotes-within-single-quoted-strings
+
+if [ "${compiler}" == "msys2" ]
+then
+  winpty -Xallow-non-tty psql -d postgres -c 'SELECT * FROM pg_available_extensions WHERE name = '\''plr'\'';'
+else
+                         psql -d postgres -c 'SELECT * FROM pg_available_extensions WHERE name = '\''plr'\'';'
+fi
+
+if [ "${compiler}" == "msys2" ]
+then
+  winpty -Xallow-non-tty psql -d postgres -c 'SELECT   r_version();'
+else
+                         psql -d postgres -c 'SELECT   r_version();'
+fi
+
+if [ "${compiler}" == "msys2" ]
+then
+  winpty -Xallow-non-tty psql -d postgres -c 'DROP EXTENSION plr;'
+else
+                         psql -d postgres -c 'DROP EXTENSION plr;'
+fi
+
+# must stop, else Appveyor job will hang.
+pg_ctl -D ${PGDATA} -l logfile stop
+
+set +v +x +e
+# set +e
+
+logok "BEGIN build_script.sh"
+

--- a/init.sh
+++ b/init.sh
@@ -1,0 +1,131 @@
+
+cd "$(dirname "$0")"
+
+# mypaint/windows/msys2-build.sh
+# https://github.com/mypaint/mypaint/blob/4141a6414b77dcf3e3e62961f99b91d466c6fb52/windows/msys2-build.sh
+#
+# ANSI control codes
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+CYAN='\033[0;36m'
+NC='\033[0m' # No Color
+
+loginfo() {
+  # set +v +x
+  echo -ne "${CYAN}"
+  echo -n "$@"
+  echo -e "${NC}"
+  # set -v -x
+}
+
+logok() {
+  # set +v +x
+  echo -ne "${GREEN}"
+  echo -n "$@"
+  echo -e "${NC}"
+  # set -v -x
+}
+
+logerr() {
+  # set +v +x
+  echo -ne "${RED}ERROR: "
+  echo -n "$@"
+  echo -e "${NC}"
+  # set -v -x
+}
+
+logok "BEGIN init.sh"
+
+set -v -x -e
+# set -e
+
+# pwd
+# /c/projects/plr
+
+loginfo "uname -a $(uname -a)"
+
+export R_HOME=$(cygpath "${R_HOME}")
+loginfo "R_HOME ${R_HOME}"
+
+#
+# "pgsource" variable
+# is only used about a custom PostgreSQL build (not an MSYS2 or CYGWIN already compiled binary)
+# 
+
+if [ ! "${pg}" == "none" ]
+then
+  export pgsource=$(cygpath "c:\projects\postgresql")
+  loginfo "pgsource ${pgsource}"
+fi
+
+export APPVEYOR_BUILD_FOLDER=$(cygpath "${APPVEYOR_BUILD_FOLDER}")
+# echo $APPVEYOR_BUILD_FOLDER
+# /c/projects/plr
+
+# 
+# echo ${MINGW_PREFIX}
+# /mingw64
+
+if [ ! "${pg}" == "none" ]
+then
+  export pgroot=$(cygpath "${pgroot}")
+else
+  export pgroot=${MINGW_PREFIX}
+  # cygwin override
+  if [ "${compiler}" == "cygwin" ]
+  then
+    # override (not all executables use "/usr/bin": initdb, postgres, and pg_ctl are in "/usr/sbin")
+    export pgroot=/usr
+  fi
+fi
+loginfo "pgroot $pgroot"
+
+# proper for "initdb" - see the PostgreSQL docs
+export TZ=UTC
+
+# e.g., in the users home directory
+
+# msys2 case
+if [ "${compiler}" == "msys2" ]
+then
+     export PGAPPDIR="C:/msys64$HOME"${pgroot}/postgresql/Data
+fi
+#
+# cygwin case
+if [ "${compiler}" == "cygwin" ]
+then
+  if [ "${Platform}" == "x64" ]
+  then
+    export PGAPPDIR=/cygdrive/c/cygwin64${HOME}${pgroot}/postgresql/Data
+  else
+    export PGAPPDIR=/cygdrive/c/cygwin${HOME}${pgroot}/postgresql/Data
+  fi
+fi
+#
+# add OTHER cases HERE: future arm* (guessing now)
+if [ "${PGAPPDIR}" == "" ]
+then
+    export PGAPPDIR="$HOME"${pgroot}/postgresql/Data
+fi
+
+export     PGDATA=${PGAPPDIR}
+export      PGLOG=${PGAPPDIR}/log.txt
+
+# R.dll in the PATH
+# not required in compilation
+#     required in "CREATE EXTENSION plr;" and regression tests
+
+# R in msys2 does sub architectures
+if [ "${compiler}" == "msys2" ]
+then
+  export PATH=${R_HOME}/bin${R_ARCH}:${PATH}
+else 
+  # cygwin does-not-do R sub architectures
+  export PATH=${R_HOME}/bin:${PATH}
+fi
+loginfo "R_HOME is in the PATH $(echo ${PATH})"
+
+set +v +x +e
+# set +e
+
+logok "END   init.sh"

--- a/install.md
+++ b/install.md
@@ -11,7 +11,7 @@ This presumes you installed PostgreSQL using the PGDG repositories found [here](
 yum install plr-nn
 ```
 
-Where nn is the major version number such as 15 for PostgreSQL version 15.x
+Where nn is the major version number such as 16 for PostgreSQL version 16.x
 
 To set R_HOME for use by PostgreSQL.
 
@@ -73,8 +73,8 @@ You may explicitly include the path of pg_config to `PATH`, such as
 
 ```bash
 cd plr
-PATH=/usr/pgsql-15/bin/:$PATH; USE_PGXS=1 make
-echo "PATH=/usr/pgsql-15/bin/:$PATH; USE_PGXS=1 make install" | sudo sh
+PATH=/usr/pgsql-16/bin/:$PATH; USE_PGXS=1 make
+echo "PATH=/usr/pgsql-16/bin/:$PATH; USE_PGXS=1 make install" | sudo sh
 ```
 If you want to use git to pull the repository, run the following command before the make command:
 
@@ -94,8 +94,8 @@ USE_PGXS=1 make install
 
 In MSYS:
 ```
-export R_HOME=/c/progra~1/R/R-4.2.1
-export PATH=$PATH:/c/progra~1/PostgreSQL/15/bin
+export R_HOME=/c/progra~1/R/R-4.3.1
+export PATH=$PATH:/c/progra~1/PostgreSQL/16/bin
 USE_PGXS=1 make
 USE_PGXS=1 make install
 ```
@@ -115,16 +115,16 @@ that has been downloaded (and installed) from
 then, include the environment variable R_ARCH.
 For example R_ARCH=/x64 (or R_ARCH=/i386 as appropriate):
 ```
-export R_HOME=/c/progra~1/R/R-4.1.3
-export PATH=$PATH:/c/progra~1/PostgreSQL/15/bin
+export R_HOME=/c/progra~1/R/R-4.3.1
+export PATH=$PATH:/c/progra~1/PostgreSQL/16/bin
 export R_ARCH=/x64
 USE_PGXS=1 make
 USE_PGXS=1 make install
 ```
 ```
-export R_HOME=/c/progra~1/R/R-4.2.1
-export PATH=$PATH:/c/progra~1/PostgreSQL/15/bin
-export R_ARCH=/x64
+export R_HOME=/c/progra~1/R/R-4.1.3
+export PATH=$PATH:/c/progra~1/PostgreSQL/16/bin
+export R_ARCH=/i386
 USE_PGXS=1 make
 USE_PGXS=1 make install
 ```
@@ -132,7 +132,25 @@ Note, R 4.2.0 and greater is not "single architecture."
 It is still "subarchitecture" with only 64bit.
 32bit has been removed.
 
+### Compiling from source and using R for Windows 4.3.0 and later
 
+PL/R that uses R for Windows 4.3.0 and later can no longer be compiled using Microsoft Visual Studio.
+One may read the following.
+
+Status: CLOSED WONTFIX
+[Bug 18544 - private_data_c Visual Studio 2022 R-4.3.0 Complex.h(81,21): syntax error: missing ';' before identifier 'private_data_c'](https://bugs.r-project.org/show_bug.cgi?id=18544)
+
+[The new definition does not work with MSVC compilers because they don't support the C99 _Complex type](https://learn.microsoft.com/en-us/cpp/c-runtime-library/complex-math-support?view=msvc-170)
+
+[C Complex Numbers in C++?](https://stackoverflow.com/questions/10540228/c-complex-numbers-in-c)
+
+Instead, for PL/R that uses R for Windows 4.3.0 and later, compile PL/R with MSYS2(UCRT64 or MINGW32).
+
+### Compiling from source using the meson build system
+
+Needed is the PostgreSQL version 16 or later source code, libR installed, PATH set, and R_HOME set. One passes -DR_HOME=value to the `meson setup` command.
+
+Alternately, needed are the PostgreSQL pre-compiled binaries. PostgreSQL can be a version lower than 16. Also needed are the libR installed, libpq installed, libpostgres configured and installed, PATH set, and R_HOME set.  One passes -DR_HOME=value and -DPG_HOME=value2 to the `meson setup` command.
 
 ### Installing from a Pre-Built "plr"
 
@@ -141,7 +159,7 @@ changing:
 
 In Windows environment (generally):
 ```
-R_HOME=C:\Progra~1\R\R-4.2.1
+R_HOME=C:\Progra~1\R\R-4.3.1
 Path=%PATH%;%R_HOME%\x64\bin
 ```
 
@@ -162,13 +180,10 @@ https://cran.r-project.org/doc/manuals/r-release/NEWS.html
 Acquire UCRT through `Windows Update` or at the following URL query result:
 https://www.google.com/search?q=download+UCRT
 
-In a Windows environment, with a PL/R compiled
-using Microsoft Visual Studio [https://github.com/postgres-plr/plr/releases/latest](https://github.com/postgres-plr/plr/releases/latest),
-with a PostgreSQL compiled
+In a Windows environment, with a PL/R compiled using MSYS2(UCRT64 or MINGW32) or Microsoft Visual Studio
+[https://github.com/postgres-plr/plr/releases/latest](https://github.com/postgres-plr/plr/releases/latest), with a PostgreSQL compiled
 with Microsoft Visual Studio [https://www.enterprisedb.com/downloads/postgres-postgresql-downloads](https://www.enterprisedb.com/downloads/postgres-postgresql-downloads),
-and an R acquired
-from [https://cran.r-project.org/bin/windows/base/](https://cran.r-project.org/bin/windows/base/)
-do the following.
+and an R acquired from CRAN [https://cran.r-project.org/bin/windows/base/](https://cran.r-project.org/bin/windows/base/) do the following.
 
 
 
@@ -177,17 +192,18 @@ do the following.
 
 Download and install PostgreSQL compiled with Microsoft Visual Studio
 [https://www.enterprisedb.com/downloads/postgres-postgresql-downloads](https://www.enterprisedb.com/downloads/postgres-postgresql-downloads)
-Download PL/R compiled using Microsoft Visual Studio
+For R versions earlier than 4.3.0 Download PL/R compiled using Microsoft Visual Studio
+For R versions greather or equal to 4.3.0 Download PL/R compiled using MSYS2 (UCRT64 or MINGW32)
 [https://github.com/postgres-plr/plr/releases/latest](https://github.com/postgres-plr/plr/releases/latest)
 
 Unzip the plr.zip file into a folder, that is called the "unzipped folder".
-If your installation of PostgreSQL had been installed into "C:\Program Files\PostgreSQL\15",
+If your installation of PostgreSQL had been installed into "C:\Program Files\PostgreSQL\16",
 then from the unzipped PL/R folder, place the following
 
  * .sql files and the plr.control file, all found in the "share\extension" folder
-   into "C:\Program Files\PostgreSQL\15\share\extension" folder.
+   into "C:\Program Files\PostgreSQL\16\share\extension" folder.
 
- * plr.dll file found in the "lib" folder into "C:\Program Files\PostgreSQL\15\lib" folder.
+ * plr.dll file found in the "lib" folder into "C:\Program Files\PostgreSQL\16\lib" folder.
 
 
 
@@ -203,7 +219,7 @@ and choose [ ] "Save version number in registry".
 At a Command Prompt run (and may have to be an Administrator Command Prompt)
 and using wherever your path to R may be, do:
 ```
-setx R_HOME "C:\Program Files\R\R-4.2.1" /M
+setx R_HOME "C:\Program Files\R\R-4.3.1" /M
 ```
 ### Optionally:
 
@@ -212,7 +228,7 @@ and choose [ ] "Save version number in registry".
 Choose Control Panel -> System -> advanced system settings -> Environment Variables button.
 In the "System variables" area, create the System Variable, called R_HOME.
 Give R_HOME the value of the PATH to the R home,
-for example (without quotes) "C:\Program Files\R\R-4.2.1".
+for example (without quotes) "C:\Program Files\R\R-4.3.1".
 
 If you forgot to set the R_HOME environment variable (by any method),
 then (eventually) you may get this error:
@@ -234,8 +250,8 @@ Control Panel -> System -> Advanced System Settings -> Environment Variables but
 In the "System variables" area, choose the System Variable, called "Path".
 Click on the Edit button.
 Add the R.dll folder to the "Path".
-For example (without quotes), add "C:\Program Files\R\R-4.2.1\bin\x64" or
-"C:\Program Files\R\R-4.1.3\bin\x64"  or "C:\Program Files\R\R-4.1.3\bin\i386".
+For example (without quotes), add "C:\Program Files\R\R-4.3.1\bin\x64" or
+or "C:\Program Files\R\R-4.1.3\bin\i386".
 If you are running R version 2.11 or earlier on Windows, the R.dll folder is different;
 instead of "bin\i386" or "bin\x64", it is "bin".
 Note, a 64bit compiled PL/R can only run with a 64bit compiled PostgreSQL.
@@ -254,21 +270,21 @@ Restart the PostgreSQL cluster, do:
 At a Command Prompt run (and you may have to be in an Administrator Command Prompt):
 Use the service name of whatever service your PostgreSQL is running under.
 ```
-net stop  postgresql-x64-15
+net stop  postgresql-x64-16
 ```
 Alternately, do the following:
 Control Panel -> Administrative Tools -> Services
-Find postgresql-x64-15 (or whatever service your PostgreSQL is running under).
+Find postgresql-x64-16 (or whatever service your PostgreSQL is running under).
 Right click and choose "Stop"
 
 At a Command Prompt run (and you may have to be in an Administrator Command Prompt):
 Use the service name of whatever service your PostgreSQL is running under.
 ```
-net start  postgresql-x64-15
+net start  postgresql-x64-16
 ```
 Alternately, do the following:
 Control Panel -> Administrative Tools -> Services
-Find postgresql-x64-15 (or whatever service your PostgreSQL is running under).
+Find postgresql-x64-16 (or whatever service your PostgreSQL is running under).
 Right click and choose "Start"
 
 

--- a/libR.pc
+++ b/libR.pc
@@ -1,0 +1,15 @@
+rhome=R_HOME
+rarch=R_ARCH
+prefix=${rhome}
+exec_prefix=${prefix}
+
+r_libdir1x=${rhome}/bin${rarch}
+r_libdir2x=${rhome}/lib${rarch}
+rincludedir=${rhome}/include
+
+Name: libR
+Description: R as a library
+Version: rversion
+Libs: -fopenmp   -L${r_libdir1x} -L${r_libdir2x} -lR
+Cflags: -I${rincludedir} -I${rincludedir}
+Libs.private:

--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,73 @@
+
+plr_sources = files(
+  'plr.c',
+  'pg_conversion.c',
+  'pg_backend_support.c',
+  'pg_userfuncs.c',
+  'pg_rsupport.c',
+)
+
+plr_regress = [
+  'plr',
+  'bad_fun',
+  'opt_window',
+  'do',
+  'out_args',
+  'plr_transaction',
+  'opt_window_frame',
+]
+
+R_home = get_option('R_HOME')
+if R_home == ''
+  error('One must supply: -DR_HOME=newvalue')
+endif
+
+plr_deps = []
+dep_R = dependency('libR')
+plr_deps +=  dep_R
+
+plr_incdir = []
+R_incdir = include_directories(R_home / 'include')
+plr_incdir += R_incdir
+
+if host_system == 'windows'
+  plr_sources += rc_lib_gen.process(win32ver_rc, extra_args: [
+    '--NAME', 'plr',
+    '--FILEDESC', 'PL/R - PostgreSQL support for R as a procedural language (PLR)',])
+endif
+
+plr = shared_module('plr',
+  plr_sources,
+  c_pch: pch_postgres_h,
+  include_directories: plr_incdir,
+  kwargs: contrib_mod_args + {
+    'dependencies': [plr_deps, contrib_mod_args['dependencies']]
+  },
+)
+
+contrib_targets += plr
+
+install_data(
+  'plr--unpackaged--8.4.6.sql',
+  'plr--8.3.0.18--8.4.sql',
+  'plr--8.4.1--8.4.2.sql',
+  'plr--8.4.3--8.4.4.sql',
+  'plr--8.4--8.4.1.sql',
+  'plr--8.4.2--8.4.3.sql',
+  'plr--8.4.4--8.4.5.sql',
+  'plr--8.4.5--8.4.6.sql',
+  'plr--8.4.6.sql',
+  'plr.control',
+  kwargs: contrib_data_args,
+)
+
+tests += {
+  'name': 'plr',
+  'sd': meson.current_source_dir(),
+  'bd': meson.current_build_dir(),
+  'regress': {
+    'sql': [
+      plr_regress
+    ],
+  },
+}

--- a/pggithubbincachefailingfound.sh
+++ b/pggithubbincachefailingfound.sh
@@ -1,0 +1,14 @@
+
+set -v -x
+
+cd "$(dirname "$0")"
+
+curl -o THROWAWAYFILE --head --fail -L ${pggithubbincacheurl}
+if [ $? -eq 0 ]
+then
+  echo false > $(cygpath ${APPVEYOR_BUILD_FOLDER})/pggithubbincachefailingfound.txt
+else
+  echo true  > $(cygpath ${APPVEYOR_BUILD_FOLDER})/pggithubbincachefailingfound.txt
+fi
+
+set +v +x

--- a/server_version_num.sh
+++ b/server_version_num.sh
@@ -1,0 +1,13 @@
+
+set -v -x
+
+cd "$(dirname "$0")"
+
+# remove whitespace and empty lines -- except remains: last line that is empty
+sed -i -r -e  's/\s+//g' -e '/^$/d' $(cygpath ${APPVEYOR_BUILD_FOLDER})/server_version_num.txt
+
+# remove the only and last empty line
+echo -n $(cat $(cygpath ${APPVEYOR_BUILD_FOLDER})/server_version_num.txt) > $(cygpath ${APPVEYOR_BUILD_FOLDER})/server_version_num.txt
+
+set +v +x
+

--- a/test_script.sh
+++ b/test_script.sh
@@ -1,0 +1,54 @@
+
+cd "$(dirname "$0")"
+
+. ./init.sh
+
+logok "BEGIN test_script.sh"
+
+set -v -x -e
+# set -e
+
+# put this in all non-init.sh scripts - pgroot is empty, if using an msys2 binary
+# but psql is already in the path
+if [ -f "${pgroot}/bin/psql" ]
+then
+  export PATH=${pgroot}/bin:${PATH}
+fi
+#
+# cygwin # pgroot: /usr - is the general location of binaries (psql) and already in the PATH
+#
+# $ echo $(cygpath "C:\cygwin\bin")
+# /usr/bin
+#
+# cygwin # initdb, postgres, and pg_ctl are here "/usr/sbin"
+if [ -f "${pgroot}/sbin/postgres" ]
+then
+  export PATH=${pgroot}/sbin:${PATH}
+fi
+
+loginfo "BEGIN verified that PLR has linked to the correct postgreSQL"
+loginfo "which psql : $(which psql)"
+loginfo "which pg_ctl: $(which pg_ctl)"
+loginfo "which initdb: $(which initdb)"
+loginfo "which postgres: $(which postgres)"
+loginfo "which pg_config: $(which pg_config)"
+logok   "pg_config . . ."
+pg_config
+loginfo "END   verified that PLR has linked to the correct postgreSQL"
+
+pg_ctl -D ${PGDATA} -l logfile start
+
+loginfo "BEGIN plr INSTALLCHECK"
+USE_PGXS=1 make installcheck || (cat regression.diffs && false)
+loginfo "END plr INSTALLCHECK"
+
+# must stop, else Appveyor job will hang.
+pg_ctl -D ${PGDATA} -l logfile stop
+
+# USE_PGXS=1 make clean
+# rm -r ${PGDATA}
+
+set +v +x +e
+# set +e
+
+logok "END   test_script.sh"

--- a/userguide.md
+++ b/userguide.md
@@ -64,7 +64,6 @@ new data types.
 
 1. [http://www.r-project.org/](http://www.r-project.org/)
 
-
 ## Installation <a name='installation'></a>
 
 All of the following presume that you have installed R before starting.
@@ -78,7 +77,7 @@ This presumes you installed PostgreSQL using the PGDG repositories found [here](
 yum install plr-nn
 ```
 
-Where nn is the major version number such as 15 for PostgreSQL version 15.x
+Where nn is the major version number such as 16 for PostgreSQL version 16.x
 
 To set R_HOME for use by PostgreSQL.
 
@@ -140,8 +139,8 @@ You may explicitly include the path of pg_config to `PATH`, such as
 
 ```bash
 cd plr
-PATH=/usr/pgsql-15/bin/:$PATH; USE_PGXS=1 make
-echo "PATH=/usr/pgsql-15/bin/:$PATH; USE_PGXS=1 make install" | sudo sh
+PATH=/usr/pgsql-16/bin/:$PATH; USE_PGXS=1 make
+echo "PATH=/usr/pgsql-16/bin/:$PATH; USE_PGXS=1 make install" | sudo sh
 ```
 If you want to use git to pull the repository, run the following command before the make command:
 
@@ -161,8 +160,8 @@ USE_PGXS=1 make install
 
 In MSYS:
 ```
-export R_HOME=/c/progra~1/R/R-4.2.1
-export PATH=$PATH:/c/progra~1/PostgreSQL/15/bin
+export R_HOME=/c/progra~1/R/R-4.3.1
+export PATH=$PATH:/c/progra~1/PostgreSQL/16/bin
 USE_PGXS=1 make
 USE_PGXS=1 make install
 ```
@@ -182,16 +181,16 @@ that has been downloaded (and installed) from
 then, include the environment variable R_ARCH.
 For example R_ARCH=/x64 (or R_ARCH=/i386 as appropriate):
 ```
-export R_HOME=/c/progra~1/R/R-4.1.3
-export PATH=$PATH:/c/progra~1/PostgreSQL/15/bin
+export R_HOME=/c/progra~1/R/R-4.3.1
+export PATH=$PATH:/c/progra~1/PostgreSQL/16/bin
 export R_ARCH=/x64
 USE_PGXS=1 make
 USE_PGXS=1 make install
 ```
 ```
-export R_HOME=/c/progra~1/R/R-4.2.1
-export PATH=$PATH:/c/progra~1/PostgreSQL/15/bin
-export R_ARCH=/x64
+export R_HOME=/c/progra~1/R/R-4.1.3
+export PATH=$PATH:/c/progra~1/PostgreSQL/16/bin
+export R_ARCH=/i386
 USE_PGXS=1 make
 USE_PGXS=1 make install
 ```
@@ -199,7 +198,25 @@ Note, R 4.2.0 and greater is not "single architecture."
 It is still "subarchitecture" with only 64bit.
 32bit has been removed.
 
+### Compiling from source and using R for Windows 4.3.0 and later
 
+PL/R that uses R for Windows 4.3.0 and later can no longer be compiled using Microsoft Visual Studio.
+One may read the following.
+
+Status: CLOSED WONTFIX
+[Bug 18544 - private_data_c Visual Studio 2022 R-4.3.0 Complex.h(81,21): syntax error: missing ';' before identifier 'private_data_c'](https://bugs.r-project.org/show_bug.cgi?id=18544)
+
+[The new definition does not work with MSVC compilers because they don't support the C99 _Complex type](https://learn.microsoft.com/en-us/cpp/c-runtime-library/complex-math-support?view=msvc-170)
+
+[C Complex Numbers in C++?](https://stackoverflow.com/questions/10540228/c-complex-numbers-in-c)
+
+Instead, for PL/R that uses R for Windows 4.3.0 and later, compile PL/R with MSYS2(UCRT64 or MINGW32).
+
+### Compiling from source using the meson build system
+
+Needed is the PostgreSQL version 16 or later source code, libR installed, PATH set, and R_HOME set. One passes -DR_HOME=value to the `meson setup` command.
+
+Alternately, needed are the PostgreSQL pre-compiled binaries. PostgreSQL can be a version lower than 16. Also needed are the libR installed, libpq installed, libpostgres configured and installed, PATH set, and R_HOME set.  One passes -DR_HOME=value and -DPG_HOME=value2 to the `meson setup` command.
 
 ### Installing from a Pre-Built "plr"
 
@@ -208,7 +225,7 @@ changing:
 
 In Windows environment (generally):
 ```
-R_HOME=C:\Progra~1\R\R-4.2.1
+R_HOME=C:\Progra~1\R\R-4.3.1
 Path=%PATH%;%R_HOME%\x64\bin
 ```
 
@@ -229,13 +246,10 @@ https://cran.r-project.org/doc/manuals/r-release/NEWS.html
 Acquire UCRT through `Windows Update` or at the following URL query result:
 https://www.google.com/search?q=download+UCRT
 
-In a Windows environment, with a PL/R compiled
-using Microsoft Visual Studio [https://github.com/postgres-plr/plr/releases/latest](https://github.com/postgres-plr/plr/releases/latest),
-with a PostgreSQL compiled 
+In a Windows environment, with a PL/R compiled using MSYS2(UCRT64 or MINGW32) or Microsoft Visual Studio
+[https://github.com/postgres-plr/plr/releases/latest](https://github.com/postgres-plr/plr/releases/latest), with a PostgreSQL compiled
 with Microsoft Visual Studio [https://www.enterprisedb.com/downloads/postgres-postgresql-downloads](https://www.enterprisedb.com/downloads/postgres-postgresql-downloads),
-and an R acquired 
-from [https://cran.r-project.org/bin/windows/base/](https://cran.r-project.org/bin/windows/base/)
-do the following.
+and an R acquired from CRAN [https://cran.r-project.org/bin/windows/base/](https://cran.r-project.org/bin/windows/base/) do the following.
 
 
 
@@ -244,17 +258,18 @@ do the following.
 
 Download and install PostgreSQL compiled with Microsoft Visual Studio
 [https://www.enterprisedb.com/downloads/postgres-postgresql-downloads](https://www.enterprisedb.com/downloads/postgres-postgresql-downloads)
-Download PL/R compiled using Microsoft Visual Studio 
+For R versions earlier than 4.3.0 Download PL/R compiled using Microsoft Visual Studio
+For R versions greather or equal to 4.3.0 Download PL/R compiled using MSYS2 (UCRT64 or MINGW32)
 [https://github.com/postgres-plr/plr/releases/latest](https://github.com/postgres-plr/plr/releases/latest)
 
 Unzip the plr.zip file into a folder, that is called the "unzipped folder".
-If your installation of PostgreSQL had been installed into "C:\Program Files\PostgreSQL\15",
-then from the unzipped PL/R folder, place the following 
+If your installation of PostgreSQL had been installed into "C:\Program Files\PostgreSQL\16",
+then from the unzipped PL/R folder, place the following
 
- * .sql files and the plr.control file, all found in the "share\extension" folder 
-   into "C:\Program Files\PostgreSQL\15\share\extension" folder.
+ * .sql files and the plr.control file, all found in the "share\extension" folder
+   into "C:\Program Files\PostgreSQL\16\share\extension" folder.
 
- * plr.dll file found in the "lib" folder into "C:\Program Files\PostgreSQL\15\lib" folder.
+ * plr.dll file found in the "lib" folder into "C:\Program Files\PostgreSQL\16\lib" folder.
 
 
 
@@ -270,7 +285,7 @@ and choose [ ] "Save version number in registry".
 At a Command Prompt run (and may have to be an Administrator Command Prompt)
 and using wherever your path to R may be, do:
 ```
-setx R_HOME "C:\Program Files\R\R-4.2.1" /M
+setx R_HOME "C:\Program Files\R\R-4.3.1" /M
 ```
 ### Optionally:
 
@@ -279,7 +294,7 @@ and choose [ ] "Save version number in registry".
 Choose Control Panel -> System -> advanced system settings -> Environment Variables button.
 In the "System variables" area, create the System Variable, called R_HOME.
 Give R_HOME the value of the PATH to the R home,
-for example (without quotes) "C:\Program Files\R\R-4.2.1".
+for example (without quotes) "C:\Program Files\R\R-4.3.1".
 
 If you forgot to set the R_HOME environment variable (by any method),
 then (eventually) you may get this error:
@@ -301,8 +316,8 @@ Control Panel -> System -> Advanced System Settings -> Environment Variables but
 In the "System variables" area, choose the System Variable, called "Path".
 Click on the Edit button.
 Add the R.dll folder to the "Path".
-For example (without quotes), add "C:\Program Files\R\R-4.2.1\bin\x64" or
-"C:\Program Files\R\R-4.1.3\bin\x64"  or "C:\Program Files\R\R-4.1.3\bin\i386".
+For example (without quotes), add "C:\Program Files\R\R-4.3.1\bin\x64" or
+or "C:\Program Files\R\R-4.1.3\bin\i386".
 If you are running R version 2.11 or earlier on Windows, the R.dll folder is different;
 instead of "bin\i386" or "bin\x64", it is "bin".
 Note, a 64bit compiled PL/R can only run with a 64bit compiled PostgreSQL.
@@ -321,21 +336,21 @@ Restart the PostgreSQL cluster, do:
 At a Command Prompt run (and you may have to be in an Administrator Command Prompt):
 Use the service name of whatever service your PostgreSQL is running under.
 ```
-net stop  postgresql-x64-15
+net stop  postgresql-x64-16
 ```
 Alternately, do the following:
 Control Panel -> Administrative Tools -> Services
-Find postgresql-x64-15 (or whatever service your PostgreSQL is running under).
+Find postgresql-x64-16 (or whatever service your PostgreSQL is running under).
 Right click and choose "Stop"
 
 At a Command Prompt run (and you may have to be in an Administrator Command Prompt):
 Use the service name of whatever service your PostgreSQL is running under.
 ```
-net start  postgresql-x64-15
+net start  postgresql-x64-16
 ```
 Alternately, do the following:
 Control Panel -> Administrative Tools -> Services
-Find postgresql-x64-15 (or whatever service your PostgreSQL is running under).
+Find postgresql-x64-16 (or whatever service your PostgreSQL is running under).
 Right click and choose "Start"
 
 
@@ -380,9 +395,8 @@ DROP EXTENSION plr;
 **Tip** If a language is installed into `template1`, all subsequently created databases will have the
 language installed automatically.
 
-**Tip** In addition to the documentation, the plr.out.* files in the plr/expected folder 
+**Tip** In addition to the documentation, the plr.out.* files in the plr/expected folder
 are a good source of usage examples.
-
 
 ## Functions and Arguments <a name="functions"></a>
 
@@ -1452,7 +1466,7 @@ FROM test_data ORDER BY fyear, eps;
 For optimization reasons, constant expressions are not expanded.
 
 The corresponding `farg2`  in the `Winsorize` example above is passes with NULL value.
-Compatibility reasons exist, so that other arguments are not shifted, in functions users 
+Compatibility reasons exist, so that other arguments are not shifted, in functions users
 created with previous versions of PL/R.
 
 
@@ -1731,7 +1745,7 @@ CREATE OR REPLACE PROCEDURE transaction_test1() AS '
   for(i in 0:9)
   {
     pg.spi.exec(paste(''INSERT INTO test1 (a) VALUES ('', i, '');''))
-    if (i %% 2 == 0) 
+    if (i %% 2 == 0)
     {
       pg.spi.commit()
     } else {
@@ -1744,13 +1758,13 @@ CALL transaction_test1();
 
 SELECT * FROM test1;
 
- a | b 
+ a | b
 ---+---
- 0 | 
- 2 | 
- 4 | 
- 6 | 
- 8 | 
+ 0 |
+ 2 |
+ 4 |
+ 6 |
+ 8 |
 (5 rows)
 ```
 
@@ -1762,26 +1776,26 @@ PL/R version 8.4.2 (or later) is required.
 
 ```postgresql
 CREATE OR REPLACE FUNCTION fast_win_frame(r int, t record) RETURNS bool AS '
-identical(parent.frame(), .GlobalEnv) && 
+identical(parent.frame(), .GlobalEnv) &&
   pg.throwerror(''Parent env is global'')
-exists(''plr_window_frame'', parent.frame(), inherits=FALSE) || 
+exists(''plr_window_frame'', parent.frame(), inherits=FALSE) ||
   pg.throwerror(''No window frame data found'')
 r == farg2[[prownum, 2]][3]
 ' LANGUAGE plr WINDOW;
 
 SELECT s.r, s.p, fast_win_frame(NULLIF(r,4), (s.r, s.q)) OVER w
-FROM (SELECT r, r % 2 AS p, array_fill(CASE WHEN r=7 THEN 77 ELSE r END, ARRAY[3]) AS q 
+FROM (SELECT r, r % 2 AS p, array_fill(CASE WHEN r=7 THEN 77 ELSE r END, ARRAY[3]) AS q
       FROM generate_series(1,10) r) s
-WINDOW w AS (PARTITION BY p ORDER BY r ROWS BETWEEN UNBOUNDED PRECEDING AND 
+WINDOW w AS (PARTITION BY p ORDER BY r ROWS BETWEEN UNBOUNDED PRECEDING AND
                                                     UNBOUNDED FOLLOWING)
 ORDER BY s.r;
 
- r  | p | fast_win_frame 
+ r  | p | fast_win_frame
 ----+---+----------------
   1 | 1 | t
   2 | 0 | t
   3 | 1 | t
-  4 | 0 | 
+  4 | 0 |
   5 | 1 | t
   6 | 0 | t
   7 | 1 | f


### PR DESCRIPTION
```
appveyor.yml - In the matrix, remove the last rversion: 4.1.3 that can
               compile on x86 except keep with the last x86 PG
               version 10 for windows.

appveyor.yml - add msvc Win32(x86), add msys2 x86, add cygwin x86

appveyor.yml - When using Micrsoft Visual Studio 2017 and older,
               in the  duplicate 'plr' entry is required.
               This demonstrated and tested in the appveyor.yml matrix.

.github\workflows\build.yml - In syntax only, remove the redundant
                              version combinations. No change.

                            - Github Actions run-name

.github\workflows\schedule.yml - Github Actions run-name

install.md and userguide.md - Update the documentation to reflect
                              PostgreSQL version 16 and the
                              latest R version 4.3.1.

.github\workflows\*meson*

    - meson builds: Windows using MSYS2(UCRT64)
      and PostgreSQL 16, 15, 14, 10(x86); cygwin x64.
    - MSYS2(UCRT64) build can be configured to do two(2) regression
      tests.
    -   1. PostgreSQL for MSYS2.
    -   2. PostgreSQL for Windows (from EnterpriseDB).
    - meson.build type 1:
        PG16+ only - in-source-contrib - contrib/plr/build.meson.
        PL/R is compiled with the rest of PostgreSQL 16+.
        This build leverages the meson build system introducted in
        PostgreSQL 16.
        The user needs to guarantee/set the Rlib, PATH and R_HOME.
    - meson.build type 2: Old x86 PG version 10 and recent x64 PG
        versions from master and 16
        and tested back through PG13 - in-binary-contribplr.
        PL/R  binds to an already pre-compiled PostreSQL.
        This build is/can_be independent of any
        "meson build system introducted in PostgreSQL 16."
        The user needs to guarantee/set the
        Rlib,libpq,libpostgres, PATH and R_HOME.
    - some starter Microsoft Visual Studio support.
      Currently, only installs msvc pre-required software.

Note, of the file .github\workflows\buildPLR.yml, to send
the 'pushed tag'assets  to the Github repository release location,
one needs to setup . . .

the https://github.com/ncipollo/release-action
token: ${{ secrets.ACTIONS_CREATE_RELEASE_REPO_SECRET }}

This secret ACTIONS_CREATE_RELEASE_REPO_SECRET
has the same content (and the secret starts with the letters ghp_) as
https://github.com/settings/tokens tokens(classic)

The selected scopes are "repo" and all of its sub-scopes.
```