### PR TITLE
November 2023 updated builds 2

### DIFF
--- a/.github/workflows/buildPLR.yml
+++ b/.github/workflows/buildPLR.yml
@@ -13,9 +13,36 @@ jobs:
       # Disable fail-fast as we want results from all even if one fails.
       fail-fast: false
       matrix:
+
+      # Repository/Virtual_Machine PostgreSQL binaries are not known automatically.
+      # (See far below in the matrix.)
+      #
+      # In two matrix items, already-compiled repository found 
+      # PostreSQL already compiled binaries are used. 
+      #
+      # The repository PostgreSQL version in HERE 
+      # is not [easily] detectable ahead of the build method.
+      # Therefore, a HUMAN, must often check and set the build matrix versions
+      # in the Github Actions build matrix, before the Github Action runs.
+      # (I do not yet have an [easy automated] work around.)
+      #
+      # Already-compiled PostgreSQL binaries in repositories in these places HERE.
+      #
+      #    Type: Pull the binary from here.
+      # 1. https://packages.msys2.org/package/mingw-w64-ucrt-x86_64-postgresql
+      #
+      #    Type: Build within this virtual machine with the installed binary here.
+      # 2. https://github.com/actions/runner-images/blob/main/images/win/Windows2022-Readme.md
+      #    Note, I can not uninstall PostgreSQL for Windows. I tried.
+
+      # "next PostgreSQL" version is not known automatically.
+      #
+      # In the caseof "next PostgreSQL" (See far below in the matrix)
+      # a HUMAN must manually see the VERSION.
+
         include:
 
-          # Note, the x86 Cygwin Server will "not start" on Github Actions
+          # Note, the x86 Cygwin Server will "not start" on Github Actions.
           # Therfore cygwin x86 is "not PostgreSQL regression testable."
           #
           # Repository R and Repository Postgresql
@@ -32,10 +59,15 @@ jobs:
 
           # plr for "R 4.3.0 (and later) for Windows" can not be compiled with Microsoft Visual Studio.
           # Therefore, here, plr for "R 4.3.0 (and later) for Windows" is compiled with MSYS2(UCRT64/MINGW32).
-          # It is regression tested twice.  The first regression test is within PostgreSQL on MSYS2.
-          # The second regression test is within PostgreSQL on Windows.
+          # It is regression tested twice.  
           #
-          # Here are the reasons why plr for "R 4.3.0 (and later) for Windows" can not be compiled with Microsoft Visual Studio.
+          #   The first regression test is within PostgreSQL on MSYS2.
+          #
+          #   The second regression test is within PostgreSQL that had been compiled with Microsoft Visual Studio 
+          #   from EnterpriseDB (if available: master _RC* and _BETA* versions are often not available).
+          #
+          # Here are the reasons why plr for "R 4.3.0 (and later) for Windows" 
+          # can not be compiled with Microsoft Visual Studio.
           #
           # Bug 18544 - private_data_c Visual Studio 2022 R-4.3.0 Complex.h(81,21): syntax error: missing ';' before identifier 'private_data_c'
           # Status: CLOSED WONTFIX
@@ -83,6 +115,13 @@ jobs:
             R_HOME: 'D:\RINSTALL'
             R_ARCH: /x64
             #
+            # A HUMAN must manually see the VERSION here. (seen November 24 2023 EST)
+            # Because this is "next PostgreSQL", 
+            # if available are/is 'release candidate' REL_AA_RC# 
+            # and/or 'beta' REL_AA_BETA# version(s)
+            # then choose that 'latest' version;
+            # 'REL' is later than 'BETA'. Higher numbers are later than lower numbers. 
+            # Otherwise, just choose the latest REL_XX_Y.
             pgSRCversion: REL_16_1
             PG_SOURCE: 'D:\PGSOURCE'
             #
@@ -94,8 +133,9 @@ jobs:
             buildpgANDplrInSRCcontrib: true
             PG_HOME: 'D:\PGINSTALL'
             #
+            # This may not be available if pgSRCversion is 'RC' or 'BETA'.
             pgWINversion: 16.1-1
-            # 
+            # This may not be available if pgSRCversion is 'RC' or 'BETA'.
             MSYS2testonpgWIN: true
 
           - os: windows-latest
@@ -110,18 +150,43 @@ jobs:
             R_HOME: 'D:\RINSTALL'
             R_ARCH: /x64
             #
-            # November 2023 - MSYS2 PostgreSQL version is 15.5
+            # November 2023 - MSYS2 PostgreSQL version is 16.1
             #
+            # A HUMAN must manually see the VERSION here. (seen November 24 2023 EST)
             # See the UCRT repository postgreSQL version
+            # Build Date: 2023-11-11 17:52:53 
+            # Version: 16.1-1
             # https://packages.msys2.org/package/mingw-w64-ucrt-x86_64-postgresql
             #
-            # pgSRCversion: REL_15_5
+            # pgSRCversion: REL_16_1
             # PG_SOURCE: 'D:\PGSOURCE'
             # buildpgFromSRC: true
             # buildpgFromSRCmethod: make
             # PG_HOME: 'D:\PGINSTALL'
             #
             # download from EnterpriseDB - PostgreSQL for Windows
+            pgWINversion: 16.1-1
+            #
+            MSYS2testonpgWIN: true
+
+          - os: windows-latest
+            GithubActionsIgnoreFail: false
+            compilerEnv: UCRT64
+            shellEnv: msys2 {0}
+            compilerExe: gcc
+            Platform: x64
+            Configuration: Release
+            #
+            rversion: 4.3.2
+            R_HOME: 'D:\RINSTALL'
+            R_ARCH: /x64
+            #
+            pgSRCversion: REL_15_5
+            PG_SOURCE: 'D:\PGSOURCE'
+            buildpgFromSRC: true
+            buildpgFromSRCmethod: make
+            PG_HOME: 'D:\PGINSTALL'
+            #
             pgWINversion: 15.5-1
             #
             MSYS2testonpgWIN: true
@@ -147,6 +212,7 @@ jobs:
             # EnterpriseDB PostgreSQL for Windows
             # pgWINversion: 14.x-y
             #
+            # A HUMAN must manually see the VERSION here. (seen November 24 2023 EST)
             # November 2023 - Pre-installed Github Actions PostgreSQL for Windows version is x64-14
             # ServiceName postgresql-x64-14
             # Version 14.8

--- a/.github/workflows/buildPLR.yml
+++ b/.github/workflows/buildPLR.yml
@@ -83,7 +83,7 @@ jobs:
             R_HOME: 'D:\RINSTALL'
             R_ARCH: /x64
             #
-            pgSRCversion: REL_16_0
+            pgSRCversion: REL_16_1
             PG_SOURCE: 'D:\PGSOURCE'
             #
             # buildpgFromSRC: true
@@ -94,7 +94,7 @@ jobs:
             buildpgANDplrInSRCcontrib: true
             PG_HOME: 'D:\PGINSTALL'
             #
-            pgWINversion: 16.0-1
+            pgWINversion: 16.1-1
             # 
             MSYS2testonpgWIN: true
 
@@ -106,23 +106,23 @@ jobs:
             Platform: x64
             Configuration: Release
             #
-            rversion: 4.3.1
+            rversion: 4.3.2
             R_HOME: 'D:\RINSTALL'
             R_ARCH: /x64
             #
-            # September 2023 - MSYS2 PostgreSQL version is 15.3
+            # November 2023 - MSYS2 PostgreSQL version is 15.5
             #
             # See the UCRT repository postgreSQL version
             # https://packages.msys2.org/package/mingw-w64-ucrt-x86_64-postgresql
             #
-            # pgSRCversion: REL_15
+            # pgSRCversion: REL_15_5
             # PG_SOURCE: 'D:\PGSOURCE'
             # buildpgFromSRC: true
             # buildpgFromSRCmethod: make
             # PG_HOME: 'D:\PGINSTALL'
             #
             # download from EnterpriseDB - PostgreSQL for Windows
-            pgWINversion: 15.3-3
+            pgWINversion: 15.5-1
             #
             MSYS2testonpgWIN: true
 
@@ -134,11 +134,11 @@ jobs:
             Platform: x64
             Configuration: Release
             #
-            rversion: 4.3.1
+            rversion: 4.3.2
             R_HOME: 'D:\RINSTALL'
             R_ARCH: /x64
             #
-            pgSRCversion: REL_14_8
+            pgSRCversion: REL_14_10
             PG_SOURCE: 'D:\PGSOURCE'
             buildpgFromSRC: true
             buildpgFromSRCmethod: make
@@ -147,7 +147,7 @@ jobs:
             # EnterpriseDB PostgreSQL for Windows
             # pgWINversion: 14.x-y
             #
-            # September 2023 - Pre-installed Github Actions PostgreSQL for Windows version is x64-14
+            # November 2023 - Pre-installed Github Actions PostgreSQL for Windows version is x64-14
             # ServiceName postgresql-x64-14
             # Version 14.8
             # https://github.com/actions/runner-images/blob/main/images/win/Windows2022-Readme.md
@@ -163,17 +163,17 @@ jobs:
             Platform: x64
             Configuration: Release
             #
-            rversion: 4.3.1
+            rversion: 4.3.2
             R_HOME: 'D:\RINSTALL'
             R_ARCH: /x64
             #
-            pgSRCversion: REL_13_12
+            pgSRCversion: REL_13_13
             PG_SOURCE: 'D:\PGSOURCE'
             buildpgFromSRC: true
             buildpgFromSRCmethod: make
             PG_HOME: 'D:\PGINSTALL'
             #
-            pgWINversion: 13.12-1
+            pgWINversion: 13.13-1
             #
             MSYS2testonpgWIN: true
 
@@ -192,17 +192,17 @@ jobs:
 ##          Platform: x64
 ##          Configuration: Release
 ##          #
-##          rversion: 4.3.1
+##          rversion: 4.3.2
 ##          R_HOME: 'D:\RINSTALL'
 ##          R_ARCH: /x64
 ##          #
-##          pgSRCversion: REL_12_16
+##          pgSRCversion: REL_12_17
 ##          PG_SOURCE: 'D:\PGSOURCE'
 ##          buildpgFromSRC: true
 ##          buildpgFromSRCmethod: make
 ##          PG_HOME: 'D:\PGINSTALL'
 ##          #
-##          pgWINversion: 12.16-1
+##          pgWINversion: 12.17-1
 ##          #
 ##          MSYS2testonpgWIN: true
 
@@ -214,17 +214,17 @@ jobs:
 ##          Platform: x64
 ##          Configuration: Release
 ##          #
-##          rversion: 4.3.1
+##          rversion: 4.3.2
 ##          R_HOME: 'D:\RINSTALL'
 ##          R_ARCH: /x64
 ##          #
-##          pgSRCversion: REL_11_21
+##          pgSRCversion: REL_11_22
 ##          PG_SOURCE: 'D:\PGSOURCE'
 ##          buildpgFromSRC: true
 ##          buildpgFromSRCmethod: make
 ##          PG_HOME: 'D:\PGINSTALL'
 ##          #
-##          pgWINversion: 11.21-1
+##          pgWINversion: 11.22-1
 ##          #
 ##          MSYS2testonpgWIN: true
 
@@ -819,9 +819,9 @@ jobs:
           "${{ env.rversionlong }}.exe" /VERYSILENT /COMPONENTS=main,%R_ARCHplat% /DIR=%R_HOME% /NOICONS /TASKS=
           dir "%R_HOME%"
 
-      # Github Actions provided PostgreSQL x64-14 (as of SEPTEMBER 2023)
+      # Github Actions provided PostgreSQL x64-14 (as of November 2023)
       #
-      # # AUGUST 2023
+      # # August 2023
       # # The PL/R extension was built using PostreSQL 15
       # ServiceName postgresql-x64-14
       # Version 14.8

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,7 +15,7 @@ environment:
 
   matrix:
 
-  # cygwin - late September 2023
+  # cygwin - late November 2023
   # cygwin - all cygwin work - except x86 "dragon" "archive" - binaries are not available
 
 ##  - pg: master # non-static commit - from git
@@ -23,7 +23,7 @@ environment:
 ##    Configuration: Debug
 ##    Platform: x64
 ##    APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2022
-##    # rversion - from the already compiled "Cygwin R" - 4.3.0-1 - September 2023 - cygwin.com/packages/summary/R.html
+##    # rversion - from the already compiled "Cygwin R" - 4.3.0-1 - November 2023 - cygwin.com/packages/summary/R.html
 ##    compiler: cygwin
 ##
 ##  - pg: master # non-static commit - from git
@@ -31,47 +31,47 @@ environment:
 ##    Configuration: Debug
 ##    Platform: x86
 ##    APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2022
-##    # rversion - from the already compiled "Cygwin R" - 4.3.0-1 - September 2023 - cygwin.com/packages/summary/R.html
+##    # rversion - from the already compiled "Cygwin R" - 4.3.0-1 - November 2023 - cygwin.com/packages/summary/R.html
 ##    compiler: cygwin
 ##
-##  - pg: REL_16_RC1 # static commit - from git
+##  - pg: REL_16_1 # static commit - from git
 ##    PlatformToolset: v143
 ##    Configuration: Debug
 ##    Platform: x64
 ##    APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2022
-##    # rversion - from the already compiled "Cygwin R" - 4.3.0-1 - September 2023 - cygwin.com/packages/summary/R.html
+##    # rversion - from the already compiled "Cygwin R" - 4.3.0-1 - November 2023 - cygwin.com/packages/summary/R.html
 ##    compiler: cygwin
 ##
-##  - pg: REL_16_RC1 # static commit - from git
+##  - pg: REL_16_1 # static commit - from git
 ##    PlatformToolset: v143
 ##    Configuration: Debug
 ##    Platform: x86
 ##    APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2022
-##    # rversion - from the already compiled "Cygwin R" - 4.3.0-1 - September 2023 - cygwin.com/packages/summary/R.html
+##    # rversion - from the already compiled "Cygwin R" - 4.3.0-1 - November 2023 - cygwin.com/packages/summary/R.html
 ##    compiler: cygwin
 ##
-##  - pg: REL_15_4 # static commit - from git
+##  - pg: REL_15_5 # static commit - from git
 ##    PlatformToolset: v143
 ##    Configuration: Debug
 ##    Platform: x64
 ##    APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2022
-##    # rversion - from the already compiled "Cygwin R" - 4.3.0-1 - September 2023 - cygwin.com/packages/summary/R.html
+##    # rversion - from the already compiled "Cygwin R" - 4.3.0-1 - November 2023 - cygwin.com/packages/summary/R.html
 ##    compiler: cygwin
 ##
-##  - pg: REL_15_4 # static commit - from git
+##  - pg: REL_15_5 # static commit - from git
 ##    PlatformToolset: v143
 ##    Configuration: Debug
 ##    Platform: x86
 ##    APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2022
-##    # rversion - from the already compiled "Cygwin R" - 4.3.0-1 - September 2023 - cygwin.com/packages/summary/R.html
+##    # rversion - from the already compiled "Cygwin R" - 4.3.0-1 - November 2023 - cygwin.com/packages/summary/R.html
 ##    compiler: cygwin
 ##
-##  # from the already compiled "Cygwin PostgreSQL" - 15.3-1 - September 2023 - https://cygwin.com/packages/summary/postgresql-src.html
+##  # from the already compiled "Cygwin PostgreSQL" - 15.3-1 - November 2023 - https://cygwin.com/packages/summary/postgresql-src.html
 ##  - PlatformToolset: v143
 ##    Configuration: Release
 ##    Platform: x64
 ##    APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2022
-##    # rversion - from the already compiled "Cygwin R" - 4.3.0-1 - September 2023 - cygwin.com/packages/summary/R.html
+##    # rversion - from the already compiled "Cygwin R" - 4.3.0-1 - November 2023 - cygwin.com/packages/summary/R.html
 ##    compiler: cygwin
 
   # from the "last" compiled "Cygwin PostgreSQL" - in December 2022 - https://cygwin.com/packages/summary/postgresql-src.html
@@ -85,18 +85,18 @@ environment:
 #   # x86 "dragon" "archive" (binaries are not easily available)
 #
 #   # plr to work with
-#   # MobaXterm Version 22.2 (2022-11-15) through the recent Version 23.2 (2023-06-25) and later?
-#   # from the "last" compiled "Cygwin PostgreSQL" - in September 2022 - https://cygwin.com/packages/summary/postgresql-src.html
+#   # MobaXterm Version 22.2 (2022-11-15) through the recent Version 23.2 (2023-06-25) and later 23.4?
+#   # from the "last" compiled "Cygwin PostgreSQL" - in November 2022 - https://cygwin.com/packages/summary/postgresql-src.html
 #   - PlatformToolset: v143
 #     Configuration: Debug
 #     Platform: x86
 #     APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2022
-#     # rversion - from the already compiled "Cygwin R"  - in September 2022 - cygwin.com/packages/summary/R.html
+#     # rversion - from the already compiled "Cygwin R"  - in November 2022 - cygwin.com/packages/summary/R.html
 #     compiler: cygwin
 #     archive: mobaxterm232 # or alternately "mobaxterm"
 
 
-#   # msys2 - late September 2023
+#   # msys2 - late November 2023
 #   # msys2
 
 ##  - pg: master # branch - non-static commit - from git
@@ -104,32 +104,32 @@ environment:
 ##    Configuration: Debug
 ##    Platform: x64
 ##    APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2022
-##    rversion: 4.3.1
+##    rversion: 4.3.2
 ##    compiler: msys2
 ##
-##  - pg: REL_16_RC1 # static commit - from git
+##  - pg: REL_16_1 # static commit - from git
 ##    PlatformToolset: v143
 ##    Configuration: Debug
 ##    Platform: x64
 ##    APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2022
-##    rversion: 4.3.1
+##    rversion: 4.3.2
 ##    compiler: msys2
 ##
-##  - pg: REL_15_4 # static commit - from git # binary distributer version is volitile
+##  - pg: REL_15_5 # static commit - from git # binary distributer version is volitile
 ##    PlatformToolset: v143
 ##    Configuration: Debug
 ##    Platform: x64
 ##    APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2022
-##    rversion: 4.3.1
+##    rversion: 4.3.2
 ##    compiler: msys2
 ##
-##    # from the already compiled "MINGW64 PostgreSQL" - 15.3-2 - September 2023 - packages.msys2.org/package/mingw-w64-x86_64-postgresql
-##    # none - from the repository - September 2023 - pg 15.3-2
+##    # from the already compiled "MINGW64 PostgreSQL" - 16.1-1 - November 2023 - packages.msys2.org/package/mingw-w64-x86_64-postgresql
+##    # none - from the repository - November 2023 - pg 16.1-1
 ##  - PlatformToolset: v143
 ##    Configuration: Debug
 ##    Platform: x64
 ##    APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2022
-##    rversion: 4.3.1
+##    rversion: 4.3.2
 ##    compiler: msys2
 
     # msvc/msys2? - "pg" 10     - last version "pg" supports x86
@@ -143,7 +143,7 @@ environment:
     rversion: 4.1.3
     compiler: msys2
 
-#   # msvc - late September 2023
+#   # msvc - late November 2023
 #   # msvc
 
   # msvc - "pg" 10     - last version "pg" supports x86
@@ -165,7 +165,7 @@ environment:
     rversion: 4.1.3
     compiler: msvc
 
-#   # msvc - late September 2023 - the rest are 64bit builds
+#   # msvc - late November 2023 - the rest are 64bit builds
 #   # msvc
 
   - pg: master # non-static commit - from git
@@ -176,7 +176,7 @@ environment:
     rversion: 4.2.3
     compiler: msvc
 
-  - pg: REL_16_0 # static commit - from git
+  - pg: REL_16_1 # static commit - from git
     PlatformToolset: v143
     Configuration: Debug
     Platform: x64
@@ -184,7 +184,7 @@ environment:
     rversion: 4.2.3
     compiler: msvc
 
-  - pg: 16.0-1
+  - pg: 16.1-1
     PlatformToolset: v143
     Configuration: Release
     Platform: x64
@@ -192,7 +192,7 @@ environment:
     rversion: 4.2.3
     compiler: msvc
 
-  - pg: 15.4-1
+  - pg: 15.5-1
     PlatformToolset: v143
     Configuration: Release
     Platform: x64
@@ -200,7 +200,7 @@ environment:
     rversion: 4.2.3
     compiler: msvc
 
-  - pg: 14.9-1
+  - pg: 14.10-1
     PlatformToolset: v143
     Configuration: Release
     Platform: x64
@@ -208,7 +208,7 @@ environment:
     rversion: 4.2.3
     compiler: msvc
 
-  - pg: 13.12-1
+  - pg: 13.13-1
     PlatformToolset: v143
     Configuration: Release
     Platform: x64
@@ -216,7 +216,7 @@ environment:
     rversion: 4.2.3
     compiler: msvc
 
-  - pg: 12.16-1
+  - pg: 12.17-1
     PlatformToolset: v143
     Configuration: Release
     Platform: x64
@@ -224,7 +224,7 @@ environment:
     rversion: 4.2.3
     compiler: msvc
 
-  - pg: REL_11_21 # verify can compile pgsql.sln on msvc 2017
+  - pg: REL_11_22 # verify can compile pgsql.sln on msvc 2017
     PlatformToolset: v140
     Configuration: Debug
     Platform: x64
@@ -232,7 +232,7 @@ environment:
     rversion: 4.2.3
     compiler: msvc
 
-  - pg: 11.21-1
+  - pg: 11.22-1
     PlatformToolset: v140
     Configuration: Release
     Platform: x64


### PR DESCRIPTION
[November 2023 updated builds 2](https://github.com/AndreMikulec/plr/commit/1b14191a1eaa5cf80cf579cd61f830bff33c5d9f)
Github Actions and Appveyor . . .

From announcement
9th November 2023: PostgreSQL 16.1, 15.5, 14.10, 13.13, 12.17, and 11.22 Released!
11.22 with R-4.1.3 continues to be an x86 build.

R-4.3.2 for Windows
https://cran.r-project.org/bin/windows/base/

Github Actions specifically . . .

Note, Github Actions, is still providing postgresql-x64-14.
https://github.com/actions/runner-images/blob/main/images/windows/Windows2022-Readme.md

MSYS2 PostgreSQL repository version changed from 15.5 to 16.1
https://packages.msys2.org/package/mingw-w64-ucrt-x86_64-postgresql

Added comments(documention) on the subject:
`A HUMAN must manually see the VERSION here.`

Appveyor specifically . . .

Updated the comments of R-4.2.3 with Microsoft Visual C++