### PR TITLE
remove calls to tuplestore_donestoring(tupstore) this was a macro which was defined as a no-op

### DIFF
--- a/pg_conversion.c
+++ b/pg_conversion.c
@@ -2196,7 +2196,6 @@ get_matrix_tuplestore(SEXP rval,
 	UNPROTECT(1);
 
 	oldcontext = MemoryContextSwitchTo(per_query_ctx);
-	tuplestore_donestoring(tupstore);
 	MemoryContextSwitchTo(oldcontext);
 
 	return tupstore;
@@ -2256,7 +2255,6 @@ get_generic_tuplestore(SEXP rval,
 	UNPROTECT(1);
 
 	oldcontext = MemoryContextSwitchTo(per_query_ctx);
-	tuplestore_donestoring(tupstore);
 	MemoryContextSwitchTo(oldcontext);
 
 	return tupstore;

--- a/pg_conversion.c
+++ b/pg_conversion.c
@@ -2134,7 +2134,6 @@ get_frame_tuplestore(SEXP rval,
 	UNPROTECT(1);
 
 	oldcontext = MemoryContextSwitchTo(per_query_ctx);
-	tuplestore_donestoring(tupstore);
 	MemoryContextSwitchTo(oldcontext);
 
 	return tupstore;

--- a/pg_userfuncs.c
+++ b/pg_userfuncs.c
@@ -411,7 +411,6 @@ plr_environ(PG_FUNCTION_ARGS)
 	 */
 	ReleaseTupleDesc(tupdesc);
 
-	tuplestore_donestoring(tupstore);
 	rsinfo->setResult = tupstore;
 
 	/*


### PR DESCRIPTION

it was removed in postgres commit https://github.com/postgres/postgres/commit/75680c3d805e2323cd437ac567f0677fdfc7b680