### PR TITLE
Update PL/R of Late September 2024

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,11 @@
 name: plr CI
 run-name: plr CI - ${{ github.event.head_commit.message }}
 
-on: [push, pull_request, workflow_dispatch]
+on: 
+   push:
+   pull_request: 
+   workflow_dispatch:
+
 jobs:
   master:
     runs-on: ubuntu-latest
@@ -127,6 +131,7 @@ jobs:
           # https://apt.postgresql.org/pub/repos/apt/dists/jammy-pgdg/
           # Source: postgresql-??
           # https://apt.postgresql.org/pub/repos/apt/dists/jammy-pgdg/main/binary-amd64/Packages
+          - pg: 17
           - pg: 16
           - pg: 15
           - pg: 14

--- a/.github/workflows/buildPLRschedule.yml
+++ b/.github/workflows/buildPLRschedule.yml
@@ -1,10 +1,23 @@
-name: Meson Builds PL/R
-run-name: Meson Builds PL/R - ${{ github.event.head_commit.message }}
+name: daily Meson Builds PL/R
+run-name: daily Meson Builds PL/R - ${{ github.event.head_commit.message }}
 
 on:
    push:
    pull_request:
    workflow_dispatch:
+   schedule:
+    # * is a special character in YAML so you have to quote this string
+      - cron:  '30 1 * * *'
+
+# This is a PERFECT COPY of buildPLR.yml
+# with the following exact exceptions.
+# 1. The YAML items "name" and "run-name" is prefixed with the word "daily".
+# 2. This has a YAML item "schedule".
+# 3. This has exactly ONE matrix item . . .
+#    R bleeding edge and PostgreSQL bleeding edge (buildpgFromSRCmethod meson)
+# 4. The ONE matrix items has set ( GithubActionsIgnoreFail false ).
+# 5. Steps using actions/upload-artifact are COMMENTED out.
+# 6. Steps using ncipollo/release-action are COMMENTED out.
 
 jobs:
   build_test_install:
@@ -47,50 +60,50 @@ jobs:
 
         include:
 
-          # Note, the x86 Cygwin Server will "not start" on Github Actions.
-          # Therfore cygwin x86 is "not PostgreSQL regression testable."
-          #
-          # Repository R and Repository Postgresql
-          # Package: R
-          # https://www.cygwin.com/packages/summary/R.html
-          # Package: postgresql
-          # https://www.cygwin.com/packages/summary/postgresql.html
-          #
-          # current Cygwin repository
-          - matid: 1
-            os: windows-latest
-            GithubActionsIgnoreFail: false
-            compilerEnv: cygwin
-            Platform: x64
-            Configuration: Release
-
-          # plr for "R 4.3.0 (and later) for Windows" can not be compiled with Microsoft Visual Studio.
-          # Therefore, here, plr for "R 4.3.0 (and later) for Windows" is compiled with MSYS2(UCRT64/MINGW32).
-          # It is regression tested twice.
-          #
-          #   The first regression test is within PostgreSQL on MSYS2.
-          #
-          #   The second regression test is within PostgreSQL that had been compiled with Microsoft Visual Studio
-          #   from EnterpriseDB (if available: master _RC* and _BETA* versions are often not available).
-          #
-          # Here are the reasons why plr for "R 4.3.0 (and later) for Windows"
-          # can not be compiled with Microsoft Visual Studio.
-          #
-          # Bug 18544 - private_data_c Visual Studio 2022 R-4.3.0 Complex.h(81,21): syntax error: missing ';' before identifier 'private_data_c'
-          # Status: CLOSED WONTFIX
-          # https://bugs.r-project.org/show_bug.cgi?id=18544
-          #
-          # The new definition does not work with MSVC compilers because they don't support the C99 _Complex type
-          # https://learn.microsoft.com/en-us/cpp/c-runtime-library/complex-math-support?view=msvc-170
-          #
-          # C Complex Numbers in C++?
-          # https://stackoverflow.com/questions/10540228/c-complex-numbers-in-c
-          #
+##          # Note, the x86 Cygwin Server will "not start" on Github Actions.
+##          # Therfore cygwin x86 is "not PostgreSQL regression testable."
+##          #
+##          # Repository R and Repository Postgresql
+##          # Package: R
+##          # https://www.cygwin.com/packages/summary/R.html
+##          # Package: postgresql
+##          # https://www.cygwin.com/packages/summary/postgresql.html
+##          #
+##          # current Cygwin repository
+##          - matid: 1
+##            os: windows-latest
+##            GithubActionsIgnoreFail: false
+##            compilerEnv: cygwin
+##            Platform: x64
+##            Configuration: Release
+##
+##          # plr for "R 4.3.0 (and later) for Windows" can not be compiled with Microsoft Visual Studio.
+##          # Therefore, here, plr for "R 4.3.0 (and later) for Windows" is compiled with MSYS2(UCRT64/MINGW32).
+##          # It is regression tested twice.
+##          #
+##          #   The first regression test is within PostgreSQL on MSYS2.
+##          #
+##          #   The second regression test is within PostgreSQL that had been compiled with Microsoft Visual Studio
+##          #   from EnterpriseDB (if available: master _RC* and _BETA* versions are often not available).
+##          #
+##          # Here are the reasons why plr for "R 4.3.0 (and later) for Windows"
+##          # can not be compiled with Microsoft Visual Studio.
+##          #
+##          # Bug 18544 - private_data_c Visual Studio 2022 R-4.3.0 Complex.h(81,21): syntax error: missing ';' before identifier 'private_data_c'
+##          # Status: CLOSED WONTFIX
+##          # https://bugs.r-project.org/show_bug.cgi?id=18544
+##          #
+##          # The new definition does not work with MSVC compilers because they don't support the C99 _Complex type
+##          # https://learn.microsoft.com/en-us/cpp/c-runtime-library/complex-math-support?view=msvc-170
+##          #
+##          # C Complex Numbers in C++?
+##          # https://stackoverflow.com/questions/10540228/c-complex-numbers-in-c
+##          #
 
           # R bleeding edge and PostgreSQL bleeding edge (buildpgFromSRCmethod meson)
           - matid: 2
             os: windows-latest
-            GithubActionsIgnoreFail: true
+            GithubActionsIgnoreFail: false
             compilerEnv: UCRT64
             shellEnv: msys2 {0}
             compilerExe: gcc
@@ -108,217 +121,217 @@ jobs:
             PG_HOME: 'D:\PGINSTALL'
 
 
-          # R latest and PostgreSQL bleeding edge (buildpgFromSRCmethod meson)
-          - matid: 3
-            os: windows-latest
-            GithubActionsIgnoreFail: true
-            compilerEnv: UCRT64
-            shellEnv: msys2 {0}
-            compilerExe: gcc
-            Platform: x64
-            Configuration: Debug
-            #
-            rversion: 4.4.1
-            R_HOME: 'D:\RINSTALL'
-            R_ARCH: /x64
-            #
-            pgSRCversion: master
-            PG_SOURCE: 'D:\PGSOURCE'
-            buildpgFromSRC: true
-            buildpgFromSRCmethod: meson
-            PG_HOME: 'D:\PGINSTALL'
-
-
-          # R latest and PostgreSQL bleeding edge (buildpgANDplrInSRCcontrib true)
-          - matid: 4
-            os: windows-latest
-            GithubActionsIgnoreFail: true
-            compilerEnv: UCRT64
-            shellEnv: msys2 {0}
-            compilerExe: gcc
-            Platform: x64
-            Configuration: Debug
-            #
-            rversion: 4.4.1
-            R_HOME: 'D:\RINSTALL'
-            R_ARCH: /x64
-            #
-            # A HUMAN must manually see the VERSION here. (seen Jul 13 2024 EST)
-            # Because this is "next PostgreSQL",
-            # if available are/is 'release candidate' REL_AA_RC#
-            # and/or 'beta' REL_AA_BETA# version(s)
-            # then choose that 'latest' version;
-            # 'REL' is later than 'BETA'. Higher numbers are later than lower numbers.
-            # Otherwise, just choose the latest REL_XX_Y or better just REL_XX_STABLE
-            # https://github.com/postgres/postgres/tags
-            pgSRCversion: master
-            PG_SOURCE: 'D:\PGSOURCE'
-            #
-            # buildpgFromSRC: true
-            # buildpgFromSRCmethod: make/meson(PostgreSQL 16+)
-            #   Add meson build system (Andres Freund, Nazir Bilal Yavuz, Peter Eisentraut)
-            #   https://www.postgresql.org/docs/16/release-16.html
-            # xor
-            # buildpgANDplrInSRCcontrib: true
-            buildpgANDplrInSRCcontrib: true
-            PG_HOME: 'D:\PGINSTALL'
-
-
-          # R bleeding edge and PostgreSQL latest (buildpgFromSRCmethod meson)
-          - matid: 5
-            os: windows-latest
-            GithubActionsIgnoreFail: true
-            compilerEnv: UCRT64
-            shellEnv: msys2 {0}
-            compilerExe: gcc
-            Platform: x64
-            Configuration: Debug
-            #
-            rversion:  devel
-            R_HOME: 'D:\RINSTALL'
-            R_ARCH: /x64
-            #
-            pgSRCversion: REL_17_STABLE
-            PG_SOURCE: 'D:\PGSOURCE'
-            buildpgFromSRC: true
-            buildpgFromSRCmethod: meson
-            PG_HOME: 'D:\PGINSTALL'
-            #
-            # pgWINversion: REL_X_Y.future-future
-            #
-            # not "MSYS2testonpgWIN: true" - because no existing "PostgreSQL REL_X_Y for Windows" exists anywhere.
-            #
-            # This may not be available if pgSRCversion is 'RC' or 'BETA'.
-            # pgWINversion: x.y-z
-            # This may not be available if pgSRCversion is 'RC' or 'BETA'.
-            # MSYS2testonpgWIN: true
-            pgWINversion: 17.0-1
-            MSYS2testonpgWIN: true
-
-
-          # R latest and PostgreSQL latest (buildpgFromSRCmethod meson)
-          - matid: 6
-            os: windows-latest
-            GithubActionsIgnoreFail: false
-            compilerEnv: UCRT64
-            shellEnv: msys2 {0}
-            compilerExe: gcc
-            Platform: x64
-            Configuration: Release
-            #
-            rversion: 4.4.1
-            R_HOME: 'D:\RINSTALL'
-            R_ARCH: /x64
-            #
-            pgSRCversion: REL_17_STABLE
-            PG_SOURCE: 'D:\PGSOURCE'
-            buildpgFromSRC: true
-            buildpgFromSRCmethod: meson
-            PG_HOME: 'D:\PGINSTALL'
-            #
-            pgWINversion: 17.0-1
-            MSYS2testonpgWIN: true
-
-
-          # R latest and PostgreSQL latest (buildpgANDplrInSRCcontrib true)
-          - matid: 7
-            os: windows-latest
-            GithubActionsIgnoreFail: false
-            compilerEnv: UCRT64
-            shellEnv: msys2 {0}
-            compilerExe: gcc
-            Platform: x64
-            Configuration: Release
-            #
-            rversion: 4.4.1
-            R_HOME: 'D:\RINSTALL'
-            R_ARCH: /x64
-            #
-            pgSRCversion: REL_17_STABLE
-            PG_SOURCE: 'D:\PGSOURCE'
-            buildpgANDplrInSRCcontrib: true
-            PG_HOME: 'D:\PGINSTALL'
-            #
-            pgWINversion: 17.0-1
-            MSYS2testonpgWIN: true
-
-
-          - matid: 8
-            os: windows-latest
-            GithubActionsIgnoreFail: false
-            compilerEnv: UCRT64
-            shellEnv: msys2 {0}
-            compilerExe: gcc
-            Platform: x64
-            Configuration: Release
-            #
-            rversion: 4.4.1
-            R_HOME: 'D:\RINSTALL'
-            R_ARCH: /x64
-            #
-            pgSRCversion: REL_16_STABLE
-            PG_SOURCE: 'D:\PGSOURCE'
-            buildpgANDplrInSRCcontrib: true
-            PG_HOME: 'D:\PGINSTALL'
-            #
-            pgWINversion: 16.4-1
-            MSYS2testonpgWIN: true
-
-
-          - matid: 9
-            os: windows-latest
-            GithubActionsIgnoreFail: false
-            compilerEnv: UCRT64
-            shellEnv: msys2 {0}
-            compilerExe: gcc
-            Platform: x64
-            Configuration: Release
-            #
-            rversion: 4.4.1
-            R_HOME: 'D:\RINSTALL'
-            R_ARCH: /x64
-            #
-            pgSRCversion: REL_15_STABLE
-            PG_SOURCE: 'D:\PGSOURCE'
-            buildpgFromSRC: true
-            buildpgFromSRCmethod: make
-            PG_HOME: 'D:\PGINSTALL'
-            #
-            pgWINversion: 15.8-1
-            MSYS2testonpgWIN: true
-
-
-          - matid: 10
-            os: windows-latest
-            GithubActionsIgnoreFail: false
-            compilerEnv: UCRT64
-            shellEnv: msys2 {0}
-            compilerExe: gcc
-            Platform: x64
-            Configuration: Release
-            #
-            rversion: 4.4.1
-            R_HOME: 'D:\RINSTALL'
-            R_ARCH: /x64
-            #
-            pgSRCversion: REL_14_STABLE
-            PG_SOURCE: 'D:\PGSOURCE'
-            buildpgFromSRC: true
-            buildpgFromSRCmethod: make
-            PG_HOME: 'D:\PGINSTALL'
-            #
-            # EnterpriseDB PostgreSQL for Windows
-            # pgWINversion: 14.x-y
-            #
-            # A HUMAN must manually see the VERSION here. (seen Jul 13 2024 EST)
-            # Jul 2024 - Pre-installed Github Actions PostgreSQL for Windows version is x64-14
-            # ServiceName postgresql-x64-14
-            # Version 14.12
-            # REAFFIRMED SEP 29 2024
-            # https://github.com/actions/runner-images/blob/main/images/windows/Windows2022-Readme.md
-            # https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-software
-            #
-            MSYS2testonpgWIN: true
+##          # R latest and PostgreSQL bleeding edge (buildpgFromSRCmethod meson)
+##          - matid: 3
+##            os: windows-latest
+##            GithubActionsIgnoreFail: true
+##            compilerEnv: UCRT64
+##            shellEnv: msys2 {0}
+##            compilerExe: gcc
+##            Platform: x64
+##            Configuration: Debug
+##            #
+##            rversion: 4.4.1
+##            R_HOME: 'D:\RINSTALL'
+##            R_ARCH: /x64
+##            #
+##            pgSRCversion: master
+##            PG_SOURCE: 'D:\PGSOURCE'
+##            buildpgFromSRC: true
+##            buildpgFromSRCmethod: meson
+##            PG_HOME: 'D:\PGINSTALL'
+##
+##
+##          # R latest and PostgreSQL bleeding edge (buildpgANDplrInSRCcontrib true)
+##          - matid: 4
+##            os: windows-latest
+##            GithubActionsIgnoreFail: true
+##            compilerEnv: UCRT64
+##            shellEnv: msys2 {0}
+##            compilerExe: gcc
+##            Platform: x64
+##            Configuration: Debug
+##            #
+##            rversion: 4.4.1
+##            R_HOME: 'D:\RINSTALL'
+##            R_ARCH: /x64
+##            #
+##            # A HUMAN must manually see the VERSION here. (seen Jul 13 2024 EST)
+##            # Because this is "next PostgreSQL",
+##            # if available are/is 'release candidate' REL_AA_RC#
+##            # and/or 'beta' REL_AA_BETA# version(s)
+##            # then choose that 'latest' version;
+##            # 'REL' is later than 'BETA'. Higher numbers are later than lower numbers.
+##            # Otherwise, just choose the latest REL_XX_Y or better just REL_XX_STABLE
+##            # https://github.com/postgres/postgres/tags
+##            pgSRCversion: master
+##            PG_SOURCE: 'D:\PGSOURCE'
+##            #
+##            # buildpgFromSRC: true
+##            # buildpgFromSRCmethod: make/meson(PostgreSQL 16+)
+##            #   Add meson build system (Andres Freund, Nazir Bilal Yavuz, Peter Eisentraut)
+##            #   https://www.postgresql.org/docs/16/release-16.html
+##            # xor
+##            # buildpgANDplrInSRCcontrib: true
+##            buildpgANDplrInSRCcontrib: true
+##            PG_HOME: 'D:\PGINSTALL'
+##
+##
+##          # R bleeding edge and PostgreSQL latest (buildpgFromSRCmethod meson)
+##          - matid: 5
+##            os: windows-latest
+##            GithubActionsIgnoreFail: true
+##            compilerEnv: UCRT64
+##            shellEnv: msys2 {0}
+##            compilerExe: gcc
+##            Platform: x64
+##            Configuration: Debug
+##            #
+##            rversion:  devel
+##            R_HOME: 'D:\RINSTALL'
+##            R_ARCH: /x64
+##            #
+##            pgSRCversion: REL_17_STABLE
+##            PG_SOURCE: 'D:\PGSOURCE'
+##            buildpgFromSRC: true
+##            buildpgFromSRCmethod: meson
+##            PG_HOME: 'D:\PGINSTALL'
+##            #
+##            # pgWINversion: REL_X_Y.future-future
+##            #
+##            # not "MSYS2testonpgWIN: true" - because no existing "PostgreSQL REL_X_Y for Windows" exists anywhere.
+##            #
+##            # This may not be available if pgSRCversion is 'RC' or 'BETA'.
+##            # pgWINversion: x.y-z
+##            # This may not be available if pgSRCversion is 'RC' or 'BETA'.
+##            # MSYS2testonpgWIN: true
+##            pgWINversion: 17.0-1
+##            MSYS2testonpgWIN: true
+##
+##
+##          # R latest and PostgreSQL latest (buildpgFromSRCmethod meson)
+##          - matid: 6
+##            os: windows-latest
+##            GithubActionsIgnoreFail: false
+##            compilerEnv: UCRT64
+##            shellEnv: msys2 {0}
+##            compilerExe: gcc
+##            Platform: x64
+##            Configuration: Release
+##            #
+##            rversion: 4.4.1
+##            R_HOME: 'D:\RINSTALL'
+##            R_ARCH: /x64
+##            #
+##            pgSRCversion: REL_17_STABLE
+##            PG_SOURCE: 'D:\PGSOURCE'
+##            buildpgFromSRC: true
+##            buildpgFromSRCmethod: meson
+##            PG_HOME: 'D:\PGINSTALL'
+##            #
+##            pgWINversion: 17.0-1
+##            MSYS2testonpgWIN: true
+##
+##
+##          # R latest and PostgreSQL latest (buildpgANDplrInSRCcontrib true)
+##          - matid: 7
+##            os: windows-latest
+##            GithubActionsIgnoreFail: false
+##            compilerEnv: UCRT64
+##            shellEnv: msys2 {0}
+##            compilerExe: gcc
+##            Platform: x64
+##            Configuration: Release
+##            #
+##            rversion: 4.4.1
+##            R_HOME: 'D:\RINSTALL'
+##            R_ARCH: /x64
+##            #
+##            pgSRCversion: REL_17_STABLE
+##            PG_SOURCE: 'D:\PGSOURCE'
+##            buildpgANDplrInSRCcontrib: true
+##            PG_HOME: 'D:\PGINSTALL'
+##            #
+##            pgWINversion: 17.0-1
+##            MSYS2testonpgWIN: true
+##
+##
+##          - matid: 8
+##            os: windows-latest
+##            GithubActionsIgnoreFail: false
+##            compilerEnv: UCRT64
+##            shellEnv: msys2 {0}
+##            compilerExe: gcc
+##            Platform: x64
+##            Configuration: Release
+##            #
+##            rversion: 4.4.1
+##            R_HOME: 'D:\RINSTALL'
+##            R_ARCH: /x64
+##            #
+##            pgSRCversion: REL_16_STABLE
+##            PG_SOURCE: 'D:\PGSOURCE'
+##            buildpgANDplrInSRCcontrib: true
+##            PG_HOME: 'D:\PGINSTALL'
+##            #
+##            pgWINversion: 16.4-1
+##            MSYS2testonpgWIN: true
+##
+##
+##          - matid: 9
+##            os: windows-latest
+##            GithubActionsIgnoreFail: false
+##            compilerEnv: UCRT64
+##            shellEnv: msys2 {0}
+##            compilerExe: gcc
+##            Platform: x64
+##            Configuration: Release
+##            #
+##            rversion: 4.4.1
+##            R_HOME: 'D:\RINSTALL'
+##            R_ARCH: /x64
+##            #
+##            pgSRCversion: REL_15_STABLE
+##            PG_SOURCE: 'D:\PGSOURCE'
+##            buildpgFromSRC: true
+##            buildpgFromSRCmethod: make
+##            PG_HOME: 'D:\PGINSTALL'
+##            #
+##            pgWINversion: 15.8-1
+##            MSYS2testonpgWIN: true
+##
+##
+##          - matid: 10
+##            os: windows-latest
+##            GithubActionsIgnoreFail: false
+##            compilerEnv: UCRT64
+##            shellEnv: msys2 {0}
+##            compilerExe: gcc
+##            Platform: x64
+##            Configuration: Release
+##            #
+##            rversion: 4.4.1
+##            R_HOME: 'D:\RINSTALL'
+##            R_ARCH: /x64
+##            #
+##            pgSRCversion: REL_14_STABLE
+##            PG_SOURCE: 'D:\PGSOURCE'
+##            buildpgFromSRC: true
+##            buildpgFromSRCmethod: make
+##            PG_HOME: 'D:\PGINSTALL'
+##            #
+##            # EnterpriseDB PostgreSQL for Windows
+##            # pgWINversion: 14.x-y
+##            #
+##            # A HUMAN must manually see the VERSION here. (seen Jul 13 2024 EST)
+##            # Jul 2024 - Pre-installed Github Actions PostgreSQL for Windows version is x64-14
+##            # ServiceName postgresql-x64-14
+##            # Version 14.12
+##            # REAFFIRMED SEP 29 2024
+##            # https://github.com/actions/runner-images/blob/main/images/windows/Windows2022-Readme.md
+##            # https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-software
+##            #
+##            MSYS2testonpgWIN: true
 
     defaults:
       run:
@@ -1369,18 +1382,18 @@ jobs:
           if exist pg-artifact.7z copy pg-artifact.7z pg-matid-${{ matrix.matid }}-${{ env.os }}-${{ env.compilerEnv }}-${{ env.Platform }}-PG${{ env.pgversion }}-${{ env.Configuration }}-R${{ env.rversion }}-PGSRC${{ env.buildpgFromSRC }}-PGSRCMETH${{ env.buildpgFromSRCmethod }}-SRCCTB${{ env.buildpgANDplrInSRCcontrib }}.7z
           if exist pg-artifact.7z dir                 pg-matid-${{ matrix.matid }}-${{ env.os }}-${{ env.compilerEnv }}-${{ env.Platform }}-PG${{ env.pgversion }}-${{ env.Configuration }}-R${{ env.rversion }}-PGSRC${{ env.buildpgFromSRC }}-PGSRCMETH${{ env.buildpgFromSRCmethod }}-SRCCTB${{ env.buildpgANDplrInSRCcontrib }}.7z
 
-      # @v4 - Due to how Artifacts are created in this new version,
-      # it is no longer possible to upload to the same named Artifact multiple times.
-      # MAY 2024
-      # github.com/actions/upload-artifact
-      #
-      - name: Upload artifact PG for export for LOCAL testing
-        if: ${{ env.os == 'windows-latest' &&  env.compilerClass == 'MSYS2' && env.buildpgFromSRC == 'true' }}
-        uses: actions/upload-artifact@v4
-        with:
-          name: pg-matid-${{ matrix.matid }}-${{ env.os }}-${{ env.compilerEnv }}-${{ env.Platform }}-PG${{ env.pgversion }}-${{ env.Configuration }}-R${{ env.rversion }}-PGSRC${{ env.buildpgFromSRC }}-PGSRCMETH${{ env.buildpgFromSRCmethod }}-SRCCTB${{ env.buildpgANDplrInSRCcontrib }}
-          path: |
-            pg-matid-${{ matrix.matid }}-${{ env.os }}-${{ env.compilerEnv }}-${{ env.Platform }}-PG${{ env.pgversion }}-${{ env.Configuration }}-R${{ env.rversion }}-PGSRC${{ env.buildpgFromSRC }}-PGSRCMETH${{ env.buildpgFromSRCmethod }}-SRCCTB${{ env.buildpgANDplrInSRCcontrib }}.7z
+##      # @v4 - Due to how Artifacts are created in this new version,
+##      # it is no longer possible to upload to the same named Artifact multiple times.
+##      # MAY 2024
+##      # github.com/actions/upload-artifact
+##      #
+##      - name: Upload artifact PG for export for LOCAL testing
+##        if: ${{ env.os == 'windows-latest' &&  env.compilerClass == 'MSYS2' && env.buildpgFromSRC == 'true' }}
+##        uses: actions/upload-artifact@v4
+##        with:
+##          name: pg-matid-${{ matrix.matid }}-${{ env.os }}-${{ env.compilerEnv }}-${{ env.Platform }}-PG${{ env.pgversion }}-${{ env.Configuration }}-R${{ env.rversion }}-PGSRC${{ env.buildpgFromSRC }}-PGSRCMETH${{ env.buildpgFromSRCmethod }}-SRCCTB${{ env.buildpgANDplrInSRCcontrib }}
+##          path: |
+##            pg-matid-${{ matrix.matid }}-${{ env.os }}-${{ env.compilerEnv }}-${{ env.Platform }}-PG${{ env.pgversion }}-${{ env.Configuration }}-R${{ env.rversion }}-PGSRC${{ env.buildpgFromSRC }}-PGSRCMETH${{ env.buildpgFromSRCmethod }}-SRCCTB${{ env.buildpgANDplrInSRCcontrib }}.7z
 
       - name: Windows non-msvc Meson PG and Meson PL/R Setup Compile and Non-Meson Manual Test
         if: ${{ env.os == 'windows-latest' && ( env.compilerClass == 'MSYS2' || env.compilerClass == 'cygwin' ) && env.buildpgANDplrInSRCcontrib == 'true' }}
@@ -2592,21 +2605,21 @@ jobs:
             Write-Error 'PGVER2 is missing. Please supply the PGVER2.' -ErrorAction Stop
           }
 
-      # @v4 - Due to how Artifacts are created in this new version,
-      # it is no longer possible to upload to the same named Artifact multiple times.
-      # MAY 2024
-      # github.com/actions/upload-artifact
-      #
-      - name: Try to Upload artifacts plr.dll and plr.dll.a for export for LOCAL testing
-        if: ${{ always() }}
-        uses: actions/upload-artifact@v4
-        with:
-          name: plr-matid-${{ matrix.matid }}-${{ env.HEAD8_GITHUB_SHA }}-${{ env.os }}-${{ env.compilerEnv }}-${{ env.Platform }}-R${{ env.rversion }}-PG${{ env.pgversion }}-${{ env.Configuration }}
-          # default
-          if-no-files-found: warn
-          path: |
-            tmp\*\*
-            tmp\PLR_LICENSE
+##      # @v4 - Due to how Artifacts are created in this new version,
+##      # it is no longer possible to upload to the same named Artifact multiple times.
+##      # MAY 2024
+##      # github.com/actions/upload-artifact
+##      #
+##      - name: Try to Upload artifacts plr.dll and plr.dll.a for export for LOCAL testing
+##        if: ${{ always() }}
+##        uses: actions/upload-artifact@v4
+##        with:
+##          name: plr-matid-${{ matrix.matid }}-${{ env.HEAD8_GITHUB_SHA }}-${{ env.os }}-${{ env.compilerEnv }}-${{ env.Platform }}-R${{ env.rversion }}-PG${{ env.pgversion }}-${{ env.Configuration }}
+##          # default
+##          if-no-files-found: warn
+##          path: |
+##            tmp\*\*
+##            tmp\PLR_LICENSE
 
       - name: Set R_HOME and PG PATH, Start PG(read OS variables), Test on PostgreSQL for Windows
         if: ${{ env.os == 'windows-latest' && env.compilerClass == 'MSYS2' && env.MSYS2testonpgWIN == 'true' }}
@@ -2696,16 +2709,16 @@ jobs:
           if exist plr-artifact.zip copy plr-artifact.zip plr-matid-${{ matrix.matid }}-${{ env.HEAD8_GITHUB_SHA }}-${{ env.os }}-${{ env.compilerEnv }}-${{ env.Platform }}-R${{ env.rversion }}-PG${{ env.pgversion }}-${{ env.Configuration }}.zip
           if exist plr-artifact.zip dir                   plr-matid-${{ matrix.matid }}-${{ env.HEAD8_GITHUB_SHA }}-${{ env.os }}-${{ env.compilerEnv }}-${{ env.Platform }}-R${{ env.rversion }}-PG${{ env.pgversion }}-${{ env.Configuration }}.zip
 
-      # Testing is not done here.
-      # Pushing this tag assumes that the previous Github Actions workflow run had all 'successes'.
-      - name: PL/R Artifact for Release
-        if: github.ref_type == 'tag'
-        uses: ncipollo/release-action@v1
-        with:
-          allowUpdates: true
-          replacesArtifacts: true
-          # "artifacts" means "paths" and "files"
-          # set of paths representing artifacts to upload to the release
-          artifacts: |
-            plr-matid-${{ matrix.matid }}-${{ env.HEAD8_GITHUB_SHA }}-${{ env.os }}-${{ env.compilerEnv }}-${{ env.Platform }}-R${{ env.rversion }}-PG${{ env.pgversion }}-${{ env.Configuration }}.zip
-          token: ${{ secrets.ACTIONS_CREATE_RELEASE_REPO_SECRET }}
+##      # Testing is not done here.
+##      # Pushing this tag assumes that the previous Github Actions workflow run had all 'successes'.
+##      - name: PL/R Artifact for Release
+##        if: github.ref_type == 'tag'
+##        uses: ncipollo/release-action@v1
+##        with:
+##          allowUpdates: true
+##          replacesArtifacts: true
+##          # "artifacts" means "paths" and "files"
+##          # set of paths representing artifacts to upload to the release
+##          artifacts: |
+##            plr-matid-${{ matrix.matid }}-${{ env.HEAD8_GITHUB_SHA }}-${{ env.os }}-${{ env.compilerEnv }}-${{ env.Platform }}-R${{ env.rversion }}-PG${{ env.pgversion }}-${{ env.Configuration }}.zip
+##          token: ${{ secrets.ACTIONS_CREATE_RELEASE_REPO_SECRET }}

--- a/.github/workflows/schedule.yml
+++ b/.github/workflows/schedule.yml
@@ -1,7 +1,7 @@
 # This is a basic workflow to help you get started with Actions
 
-name: plr daily
-run-name: plr daily - ${{ github.event.head_commit.message }}
+name: daily plr
+run-name: daily plr - ${{ github.event.head_commit.message }}
 
 on: 
    push:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,10 +1,11 @@
 
-# Skipping commits affecting specific files (GitHub and Bitbucket only).
-skip_commits:
-  files:
-    # skipping AppVeyor build if, in the push’s head commit, all of the files
-    # have the extension .md
-    - '**/*.md'
+
+##  # Skipping commits affecting specific files (GitHub and Bitbucket only).
+##  skip_commits:
+##    files:
+##      # skipping AppVeyor build if, in the push’s head commit, all of the files
+##      # have the extension .md
+##      - '**/*.md'
 
 image: Visual Studio 2015
 clone_depth: 1
@@ -197,7 +198,7 @@ environment:
     rversion: 4.2.3
     compiler: msvc
 
-  - pg: 16.3-2
+  - pg: 16.4-1
     PlatformToolset: v143
     Configuration: Release
     Platform: x64
@@ -205,7 +206,7 @@ environment:
     rversion: 4.2.3
     compiler: msvc
 
-  - pg: 15.7-2
+  - pg: 15.8-1
     PlatformToolset: v143
     Configuration: Release
     Platform: x64
@@ -213,7 +214,7 @@ environment:
     rversion: 4.2.3
     compiler: msvc
 
-  - pg: 14.12-2
+  - pg: 14.13-1
     PlatformToolset: v143
     Configuration: Release
     Platform: x64
@@ -221,7 +222,7 @@ environment:
     rversion: 4.2.3
     compiler: msvc
 
-  - pg: 13.15-2
+  - pg: 13.16-1
     PlatformToolset: v143
     Configuration: Release
     Platform: x64
@@ -229,7 +230,7 @@ environment:
     rversion: 4.2.3
     compiler: msvc
 
-  - pg: 12.19-2
+  - pg: 12.20-1
     PlatformToolset: v143
     Configuration: Release
     Platform: x64
@@ -1421,9 +1422,7 @@ deploy:
     artifact: plr_7z
     auth_token:
       # Token of Dave
-      secure: nasXR/dCMdQmmouYtN0t1/9jilLmOA6E5EsGoP6Td5yvp3JK4QPfZO0BEVzMeXW1
-      # Token of Andre
-      # secure: DpxrjrmF0pQsm3G/F8m7EDVz6yhBQhlwXWOtqxgQTmUMiofL1PZD+9Q1dAqyKh9Z
+      secure: DpxrjrmF0pQsm3G/F8m7EDVz6yhBQhlwXWOtqxgQTmUMiofL1PZD+9Q1dAqyKh9Z
     on:
       APPVEYOR_REPO_TAG: true
 

--- a/install.md
+++ b/install.md
@@ -11,7 +11,7 @@ This presumes you installed PostgreSQL using the PGDG repositories found [here](
 yum install plr-nn
 ```
 
-Where nn is the major version number such as 16 for PostgreSQL version 16.x
+Where nn is the major version number such as 17 for PostgreSQL version 17.x
 
 To set R_HOME for use by PostgreSQL.
 
@@ -270,21 +270,21 @@ Restart the PostgreSQL cluster, do:
 At a Command Prompt run (and you may have to be in an Administrator Command Prompt):
 Use the service name of whatever service your PostgreSQL is running under.
 ```
-net stop postgresql-x64-16
+net stop postgresql-x64-17
 ```
 Alternately, do the following:
 Control Panel -> Administrative Tools -> Services
-Find postgresql-x64-16 (or whatever service your PostgreSQL is running under).
+Find postgresql-x64-17 (or whatever service your PostgreSQL is running under).
 Right click and choose "Stop"
 
 At a Command Prompt run (and you may have to be in an Administrator Command Prompt):
 Use the service name of whatever service your PostgreSQL is running under.
 ```
-net start postgresql-x64-16
+net start postgresql-x64-17
 ```
 Alternately, do the following:
 Control Panel -> Administrative Tools -> Services
-Find postgresql-x64-16 (or whatever service your PostgreSQL is running under).
+Find postgresql-x64-17 (or whatever service your PostgreSQL is running under).
 Right click and choose "Start"
 
 

--- a/userguide.md
+++ b/userguide.md
@@ -77,7 +77,7 @@ This presumes you installed PostgreSQL using the PGDG repositories found [here](
 yum install plr-nn
 ```
 
-Where nn is the major version number such as 16 for PostgreSQL version 16.x
+Where nn is the major version number such as 17 for PostgreSQL version 17.x
 
 To set R_HOME for use by PostgreSQL.
 
@@ -336,21 +336,21 @@ Restart the PostgreSQL cluster, do:
 At a Command Prompt run (and you may have to be in an Administrator Command Prompt):
 Use the service name of whatever service your PostgreSQL is running under.
 ```
-net stop postgresql-x64-16
+net stop postgresql-x64-17
 ```
 Alternately, do the following:
 Control Panel -> Administrative Tools -> Services
-Find postgresql-x64-16 (or whatever service your PostgreSQL is running under).
+Find postgresql-x64-17 (or whatever service your PostgreSQL is running under).
 Right click and choose "Stop"
 
 At a Command Prompt run (and you may have to be in an Administrator Command Prompt):
 Use the service name of whatever service your PostgreSQL is running under.
 ```
-net start postgresql-x64-16
+net start postgresql-x64-17
 ```
 Alternately, do the following:
 Control Panel -> Administrative Tools -> Services
-Find postgresql-x64-16 (or whatever service your PostgreSQL is running under).
+Find postgresql-x64-17 (or whatever service your PostgreSQL is running under).
 Right click and choose "Start"
 
 
@@ -1075,7 +1075,7 @@ SELECT * FROM pg_available_extensions WHERE name = 'plr';
 
  name | default_version | installed_version |                            comment
 ------+-----------------+-------------------+----------------------------------------------------------------
- plr  | 8.4.6           | 8.4.6             | load R interpreter and execute R script from within a database
+ plr  | 8.4.7           | 8.4.7             | load R interpreter and execute R script from within a database
 (1 row)
 ```
 


### PR DESCRIPTION
* Removed PG 17 betas and replaced with 17
* Upgraded github versions and EDB versions
* Cutting edge builds became Debug builds
* Cutting edge builds can fail without the build failing
* Cleaned up matrix item descriptons
* Placed matrix matid in front in many places so I can track the jobs This fail will fail the build.
* Scheduled one Windows PG/R dual "cutting edge" build job matrix item to run daily
* Replaced "meson tests" using classic "regression tests" (keeps meson builds) A PG commit broke these in non-cygin Windows PG 17+ builds. I never could get these "meson test"s re-working.
* Slightly upgraded docs to version 17
* No "C" code changes. This is still PL/R REL8_4_7