### PR TITLE
Rename "gamma" in tests to avoid clash with PG18 function

### DIFF
--- a/expected/plr.out
+++ b/expected/plr.out
@@ -328,8 +328,8 @@ select round(r_gamma('{1.23,1.31,1.42,1.27}'::_float8)::numeric,8);
  0.91075486
 (1 row)
 
-CREATE AGGREGATE gamma (sfunc = plr_array_accum, basetype = float8, stype = _float8, finalfunc = r_gamma);
-select f1, round(gamma(f2)::numeric,8) from foo group by f1 order by f1;
+CREATE AGGREGATE gamma_agg (sfunc = plr_array_accum, basetype = float8, stype = _float8, finalfunc = r_gamma);
+select f1, round(gamma_agg(f2)::numeric,8) from foo group by f1 order by f1;
   f1  |   round    
 ------+------------
  cat1 | 0.91557649

--- a/sql/plr.sql
+++ b/sql/plr.sql
@@ -153,8 +153,8 @@ select f1, median(f2) from foo group by f1 order by f1;
 
 create or replace function r_gamma(_float8) returns float as 'gamma(arg1)' language 'plr';
 select round(r_gamma('{1.23,1.31,1.42,1.27}'::_float8)::numeric,8);
-CREATE AGGREGATE gamma (sfunc = plr_array_accum, basetype = float8, stype = _float8, finalfunc = r_gamma);
-select f1, round(gamma(f2)::numeric,8) from foo group by f1 order by f1;
+CREATE AGGREGATE gamma_agg (sfunc = plr_array_accum, basetype = float8, stype = _float8, finalfunc = r_gamma);
+select f1, round(gamma_agg(f2)::numeric,8) from foo group by f1 order by f1;
 
 --
 -- test returning vectors, arrays, matricies, and dataframes


### PR DESCRIPTION
PostgreSQL 18 introduces its own gamma function which takes precedence over the gamma aggregate defined in the regression test file. Rename to avoid the problem.