### PR TITLE
[daily] Meson Builds PL/R - Replace Move-Item using "Copy-Item ... -R…

### DIFF
--- a/.github/workflows/buildPLR.yml
+++ b/.github/workflows/buildPLR.yml
@@ -817,7 +817,7 @@ jobs:
         if: ${{ env.os == 'windows-latest' && env.pgSRCversion != 'notset' }}
         shell: powershell
         run: |
-          Move-Item -Path PGSOURCE -Destination ${{ env.PG_SOURCE }}
+          Copy-Item -Path PGSOURCE -Destination ${{ env.PG_SOURCE }} -Recurse -Force
           Get-ChildItem                         ${{ env.PG_SOURCE }}
 
       # I do not want to cache "R for Windows devel version".

--- a/.github/workflows/buildPLRschedule.yml
+++ b/.github/workflows/buildPLRschedule.yml
@@ -830,7 +830,7 @@ jobs:
         if: ${{ env.os == 'windows-latest' && env.pgSRCversion != 'notset' }}
         shell: powershell
         run: |
-          Move-Item -Path PGSOURCE -Destination ${{ env.PG_SOURCE }}
+          Copy-Item -Path PGSOURCE -Destination ${{ env.PG_SOURCE }} -Recurse -Force
           Get-ChildItem                         ${{ env.PG_SOURCE }}
 
       # I do not want to cache "R for Windows devel version".


### PR DESCRIPTION
In the method to "test on Windows", `"Move-Item"` has been 
replaced with `"Copy-Item ... -Recurse -Force"`
to try to fix a bizarre Github Actions situation specific "move" security bug.

Trying to fix this error.
postgres-plr -- daily daily Meson Builds PL/R - Windows Move PostgreSQL Code - PermissionDenied #53
https://github.com/AndreMikulec/plr/issues/53

Windows Move PostgreSQL Code
```
0s
Run Move-Item -Path PGSOURCE -Destination D:\PGSOURCE
Move-Item : Cannot remove item C:\a\plr\plr\PGSOURCE\.git: You do not have sufficient access rights to perform this 
operation.
At C:\a\_temp\ebaf8f3f-2a6b-4dd7-9f8a-8082d47d0fa7.ps1:2 char:1
+ Move-Item -Path PGSOURCE -Destination D:\PGSOURCE
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : PermissionDenied: (C:\a\plr\plr\PGSOURCE\.git:DirectoryInfo) [Move-Item], IOException
    + FullyQualifiedErrorId : RemoveFileSystemItemUnAuthorizedAccess,Microsoft.PowerShell.Commands.MoveItemCommand
```
