### PR TITLE
Builds now use REL_18_STABLE that is REL_18_BETA2+,REL_18_RC#+

### DIFF
--- a/.github/workflows/buildPLR.yml
+++ b/.github/workflows/buildPLR.yml
@@ -182,7 +182,7 @@ jobs:
             R_HOME: 'D:\RINSTALL'
             R_ARCH: /x64
             #
-            pgSRCversion: REL_18_BETA1
+            pgSRCversion: REL_18_STABLE
             PG_SOURCE: 'D:\PGSOURCE'
             buildpgFromSRC: true
             buildpgFromSRCmethod: meson
@@ -214,7 +214,7 @@ jobs:
             R_HOME: 'D:\RINSTALL'
             R_ARCH: /x64
             #
-            pgSRCversion: REL_18_BETA1
+            pgSRCversion: REL_18_STABLE
             PG_SOURCE: 'D:\PGSOURCE'
             buildpgFromSRC: true
             buildpgFromSRCmethod: meson
@@ -238,7 +238,7 @@ jobs:
             R_HOME: 'D:\RINSTALL'
             R_ARCH: /x64
             #
-            pgSRCversion: REL_18_BETA1
+            pgSRCversion: REL_18_STABLE
             PG_SOURCE: 'D:\PGSOURCE'
             buildpgANDplrInSRCcontrib: true
             PG_HOME: 'D:\PGINSTALL'

--- a/.github/workflows/buildPLRschedule.yml
+++ b/.github/workflows/buildPLRschedule.yml
@@ -195,7 +195,7 @@ jobs:
 ##            R_HOME: 'D:\RINSTALL'
 ##            R_ARCH: /x64
 ##            #
-##            pgSRCversion: REL_18_BETA1
+##            pgSRCversion: REL_18_STABLE
 ##            PG_SOURCE: 'D:\PGSOURCE'
 ##            buildpgFromSRC: true
 ##            buildpgFromSRCmethod: meson
@@ -227,7 +227,7 @@ jobs:
 ##            R_HOME: 'D:\RINSTALL'
 ##            R_ARCH: /x64
 ##            #
-##            pgSRCversion: REL_18_BETA1
+##            pgSRCversion: REL_18_STABLE
 ##            PG_SOURCE: 'D:\PGSOURCE'
 ##            buildpgFromSRC: true
 ##            buildpgFromSRCmethod: meson
@@ -251,7 +251,7 @@ jobs:
 ##            R_HOME: 'D:\RINSTALL'
 ##            R_ARCH: /x64
 ##            #
-##            pgSRCversion: REL_18_BETA1
+##            pgSRCversion: REL_18_STABLE
 ##            PG_SOURCE: 'D:\PGSOURCE'
 ##            buildpgANDplrInSRCcontrib: true
 ##            PG_HOME: 'D:\PGINSTALL'

--- a/README.md
+++ b/README.md
@@ -1,7 +1,10 @@
 ### PL/R - PostgreSQL support for R as a procedural language (PL)
 [![GitHub license](https://img.shields.io/github/license/postgres-plr/plr.svg?cacheSeconds=2592000)](https://github.com/postgres-plr/plr/blob/master/LICENSE)
+[![daily plr](https://github.com/postgres-plr/plr/actions/workflows/schedule.yml/badge.svg)](https://github.com/postgres-plr/plr/actions/workflows/schedule.yml)
+[![daily Meson Builds PL/R](https://github.com/postgres-plr/plr/actions/workflows/buildPLRschedule.yml/badge.svg)](https://github.com/postgres-plr/plr/actions/workflows/buildPLRschedule.yml)
+[![plr CI](https://github.com/postgres-plr/plr/actions/workflows/build.yml/badge.svg)](https://github.com/postgres-plr/plr/actions/workflows/build.yml)
+[![Meson Builds PL/R](https://github.com/postgres-plr/plr/actions/workflows/buildPLR.yml/badge.svg)](https://github.com/postgres-plr/plr/actions/workflows/buildPLR.yml)
 [![AppVeyor build status](https://ci.appveyor.com/api/projects/status/github/postgres-plr/plr?svg=true)](https://ci.appveyor.com/project/davecramer/plr-daun5 "Get your fresh Windows build here!")
-[![Travis build Status](https://travis-ci.org/postgres-plr/plr.png)](https://travis-ci.org/postgres-plr/plr)
 [![Code coverage](https://img.shields.io/codecov/c/github/postgres-plr/plr.svg?logo=codecov&cacheSeconds=2592000)](https://codecov.io/github/postgres-plr/plr)
 [![Chat on Slack](https://img.shields.io/badge/Slack-chat-orange.svg?logo=slack&cacheSeconds=2592000)](https://postgresteam.slack.com/messages/CJQUZ1475/ "Join the conversation!")
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -401,7 +401,7 @@ for:
         # git branch or commit - alphanumeric and all lowercase letters (slower download)
         #
         if("${env:pghint}" -eq "commit") {
-          git clone -q                            https://git.postgresql.org/git/postgresql.git c:\projects\postgresql
+          git clone -q                            https://github.com/postgres/postgres c:\projects\postgresql
           pwd
           pushd c:\projects\postgresql
           pwd
@@ -415,7 +415,7 @@ for:
         # PostgreSQL case - git branches and tags have at least one capital letter - but expect mostly CAPS
         #
         } else {
-          git clone -q --depth 1 --branch ${env:pg} https://git.postgresql.org/git/postgresql.git c:\projects\postgresql
+          git clone -q --depth 1 --branch ${env:pg} https://github.com/postgres/postgres c:\projects\postgresql
           pushd c:\projects\postgresql
           pwd
           git branch
@@ -736,7 +736,7 @@ for:
         # git branch or commit - alphanumeric and all lowercase letters (slower download)
         #
         if("${env:pghint}" -eq "commit") {
-          git clone -q                            https://git.postgresql.org/git/postgresql.git c:\projects\postgresql
+          git clone -q                            https://github.com/postgres/postgres c:\projects\postgresql
           pwd
           pushd c:\projects\postgresql
           pwd
@@ -750,7 +750,7 @@ for:
         # PostgreSQL case - git branches and tags have at least one capital letter - but expect mostly CAPS
         #
         } else {
-          git clone -q --depth 1 --branch ${env:pg} https://git.postgresql.org/git/postgresql.git c:\projects\postgresql
+          git clone -q --depth 1 --branch ${env:pg} https://github.com/postgres/postgres c:\projects\postgresql
           pushd c:\projects\postgresql
           pwd
           git branch
@@ -1035,7 +1035,7 @@ for:
         # git branch or commit - alphanumeric and all lowercase letters (slower download)
         #
         if(("${env:pg}" -cmatch  "^[a-z0-9]+$") -and ("${env:pghint}" -eq "commit")) {
-          git clone -q                            https://git.postgresql.org/git/postgresql.git c:\projects\postgresql
+          git clone -q                            https://github.com/postgres/postgres c:\projects\postgresql
           pwd
           pushd c:\projects\postgresql
           pwd
@@ -1049,7 +1049,7 @@ for:
         # PostgreSQL case - git branches and tags have at least one capital letter - but expect mostly CAPS
         #
         } else {
-          git clone -q --depth 1 --branch ${env:pg} https://git.postgresql.org/git/postgresql.git c:\projects\postgresql
+          git clone -q --depth 1 --branch ${env:pg} https://github.com/postgres/postgres c:\projects\postgresql
           pushd c:\projects\postgresql
           pwd
           git branch


### PR DESCRIPTION
* Correct the build badges
* Changed Appveyor builds to use PG sources at github, replacing git.postgresql.org
* Because REL_18_STABLE(REL_18_BETA2) is now available, replace from REL_18_BETA1