### PR TITLE
Prepare for PG18

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
         run: echo building master
 
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
 
       - name: checkout postgres
         run: |
@@ -50,10 +50,10 @@ jobs:
           USE_PGXS: 1
 
   REL_18_:
-    # SEEN MAY 2025
-    # Ubuntu 24.04	ubuntu-latest
+    # SEEN AUG 2025
+    # Ubuntu 24.04 - ubuntu-latest or ubuntu-24.04
     # https://github.com/actions/runner-images
-    # noble (24.04, LTS)
+    # noble (24.04, LTS), plucky (25.04, amd64 only)
     # https://wiki.postgresql.org/wiki/Apt
     # https://apt.postgresql.org/pub/repos/apt/dists/
     runs-on: ubuntu-latest
@@ -62,7 +62,7 @@ jobs:
         run: echo building master
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: checkout postgres
         run: |
@@ -128,10 +128,10 @@ jobs:
     strategy:
       matrix:
         include:
-          # SEEN MAY 2025
-          # Ubuntu 24.04	ubuntu-latest
+          # SEEN AUG 2025
+          # Ubuntu 24.04 - ubuntu-latest or ubuntu-24.04
           # https://github.com/actions/runner-images
-          # noble (24.04, LTS)
+          # noble (24.04, LTS), plucky (25.04, amd64 only)
           # https://wiki.postgresql.org/wiki/Apt
           # https://apt.postgresql.org/pub/repos/apt/dists/
           # ##
@@ -151,7 +151,7 @@ jobs:
         run: echo PG $PG
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Before Script
         run: |

--- a/.github/workflows/buildPLR.yml
+++ b/.github/workflows/buildPLR.yml
@@ -57,12 +57,13 @@ jobs:
           # https://www.cygwin.com/packages/summary/postgresql.html
           #
           # current Cygwin repository
-          - matid: 1
-            os: windows-latest
+          - matid: 01
+            os: windows-2025
             GithubActionsIgnoreFail: false
             compilerEnv: cygwin
             Platform: x64
             Configuration: Release
+
 
           # plr for "R 4.3.0 (and later) for Windows" can not be compiled with Microsoft Visual Studio.
           # Therefore, here, plr for "R 4.3.0 (and later) for Windows" is compiled with MSYS2(UCRT64/MINGW32).
@@ -89,12 +90,12 @@ jobs:
 
           # SEEN MAY 2025 (not yet SWITCHING to windows-2025 - need to modify HARDCODED yaml from 14 to 17)
           # windows-2025 (uses PG 17)
-          # windows-latest or windows-2022 (uses PG 14)
+          # windows-2025 or windows-2025 (uses PG 14)
           # https://github.com/actions/runner-images
 
           # R bleeding edge and PostgreSQL bleeding edge (buildpgFromSRCmethod meson)
-          - matid: 2
-            os: windows-latest
+          - matid: 02
+            os: windows-2025
             GithubActionsIgnoreFail: true
             compilerEnv: UCRT64
             shellEnv: msys2 {0}
@@ -103,19 +104,19 @@ jobs:
             Configuration: Debug
             #
             rversion:  devel
-            R_HOME: 'D:\RINSTALL'
+            R_HOME: 'C:\RINSTALL'
             R_ARCH: /x64
             #
             pgSRCversion: master
-            PG_SOURCE: 'D:\PGSOURCE'
+            PG_SOURCE: 'C:\PGSOURCE'
             buildpgFromSRC: true
             buildpgFromSRCmethod: meson
-            PG_HOME: 'D:\PGINSTALL'
+            PG_HOME: 'C:\PGINSTALL'
 
 
           # R latest and PostgreSQL bleeding edge (buildpgFromSRCmethod meson)
-          - matid: 3
-            os: windows-latest
+          - matid: 03
+            os: windows-2025
             GithubActionsIgnoreFail: true
             compilerEnv: UCRT64
             shellEnv: msys2 {0}
@@ -123,20 +124,20 @@ jobs:
             Platform: x64
             Configuration: Debug
             #
-            rversion: 4.5.0
-            R_HOME: 'D:\RINSTALL'
+            rversion: 4.5.1
+            R_HOME: 'C:\RINSTALL'
             R_ARCH: /x64
             #
             pgSRCversion: master
-            PG_SOURCE: 'D:\PGSOURCE'
+            PG_SOURCE: 'C:\PGSOURCE'
             buildpgFromSRC: true
             buildpgFromSRCmethod: meson
-            PG_HOME: 'D:\PGINSTALL'
+            PG_HOME: 'C:\PGINSTALL'
 
 
           # R latest and PostgreSQL bleeding edge (buildpgANDplrInSRCcontrib true)
-          - matid: 4
-            os: windows-latest
+          - matid: 04
+            os: windows-2025
             GithubActionsIgnoreFail: true
             compilerEnv: UCRT64
             shellEnv: msys2 {0}
@@ -144,8 +145,8 @@ jobs:
             Platform: x64
             Configuration: Debug
             #
-            rversion: 4.5.0
-            R_HOME: 'D:\RINSTALL'
+            rversion: 4.5.1
+            R_HOME: 'C:\RINSTALL'
             R_ARCH: /x64
             #
             # A HUMAN must manually see the VERSION here. (seen Jul 13 2024 EST)
@@ -157,7 +158,7 @@ jobs:
             # Otherwise, just choose the latest REL_XX_Y or better just REL_XX_STABLE
             # https://github.com/postgres/postgres/tags
             pgSRCversion: master
-            PG_SOURCE: 'D:\PGSOURCE'
+            PG_SOURCE: 'C:\PGSOURCE'
             #
             # buildpgFromSRC: true
             # buildpgFromSRCmethod: make/meson(PostgreSQL 16+)
@@ -166,11 +167,12 @@ jobs:
             # xor
             # buildpgANDplrInSRCcontrib: true
             buildpgANDplrInSRCcontrib: true
-            PG_HOME: 'D:\PGINSTALL'
+            PG_HOME: 'C:\PGINSTALL'
+
 
           # R bleeding edge and PostgreSQL latest (buildpgFromSRCmethod meson)
-          - matid: 5
-            os: windows-latest
+          - matid: 05
+            os: windows-2025
             GithubActionsIgnoreFail: true
             compilerEnv: UCRT64
             shellEnv: msys2 {0}
@@ -179,14 +181,14 @@ jobs:
             Configuration: Debug
             #
             rversion:  devel
-            R_HOME: 'D:\RINSTALL'
+            R_HOME: 'C:\RINSTALL'
             R_ARCH: /x64
             #
             pgSRCversion: REL_18_STABLE
-            PG_SOURCE: 'D:\PGSOURCE'
+            PG_SOURCE: 'C:\PGSOURCE'
             buildpgFromSRC: true
             buildpgFromSRCmethod: meson
-            PG_HOME: 'D:\PGINSTALL'
+            PG_HOME: 'C:\PGINSTALL'
             #
             # pgWINversion: REL_X_Y.future-future
             #
@@ -201,8 +203,8 @@ jobs:
 
 
           # R latest and PostgreSQL latest (buildpgFromSRCmethod meson)
-          - matid: 6
-            os: windows-latest
+          - matid: 06
+            os: windows-2025
             GithubActionsIgnoreFail: false
             compilerEnv: UCRT64
             shellEnv: msys2 {0}
@@ -210,23 +212,23 @@ jobs:
             Platform: x64
             Configuration: Release
             #
-            rversion: 4.5.0
-            R_HOME: 'D:\RINSTALL'
+            rversion: 4.5.1
+            R_HOME: 'C:\RINSTALL'
             R_ARCH: /x64
             #
             pgSRCversion: REL_18_STABLE
-            PG_SOURCE: 'D:\PGSOURCE'
+            PG_SOURCE: 'C:\PGSOURCE'
             buildpgFromSRC: true
             buildpgFromSRCmethod: meson
-            PG_HOME: 'D:\PGINSTALL'
+            PG_HOME: 'C:\PGINSTALL'
             #
             # pgWINversion: 18.?-?
             MSYS2testonpgWIN: false
 
 
           # R latest and PostgreSQL latest (buildpgANDplrInSRCcontrib true)
-          - matid: 7
-            os: windows-latest
+          - matid: 07
+            os: windows-2025
             GithubActionsIgnoreFail: false
             compilerEnv: UCRT64
             shellEnv: msys2 {0}
@@ -234,53 +236,22 @@ jobs:
             Platform: x64
             Configuration: Release
             #
-            rversion: 4.5.0
-            R_HOME: 'D:\RINSTALL'
+            rversion: 4.5.1
+            R_HOME: 'C:\RINSTALL'
             R_ARCH: /x64
             #
             pgSRCversion: REL_18_STABLE
-            PG_SOURCE: 'D:\PGSOURCE'
+            PG_SOURCE: 'C:\PGSOURCE'
             buildpgANDplrInSRCcontrib: true
-            PG_HOME: 'D:\PGINSTALL'
+            PG_HOME: 'C:\PGINSTALL'
             #
             # pgWINversion: 18.?-?
             MSYS2testonpgWIN: false
 
-          # R bleeding edge and PostgreSQL latest (buildpgFromSRCmethod meson)
-          - matid: 8
-            os: windows-latest
-            GithubActionsIgnoreFail: true
-            compilerEnv: UCRT64
-            shellEnv: msys2 {0}
-            compilerExe: gcc
-            Platform: x64
-            Configuration: Debug
-            #
-            rversion:  devel
-            R_HOME: 'D:\RINSTALL'
-            R_ARCH: /x64
-            #
-            pgSRCversion: REL_17_STABLE
-            PG_SOURCE: 'D:\PGSOURCE'
-            buildpgFromSRC: true
-            buildpgFromSRCmethod: meson
-            PG_HOME: 'D:\PGINSTALL'
-            #
-            # pgWINversion: REL_X_Y.future-future
-            #
-            # not "MSYS2testonpgWIN: true" - because no existing "PostgreSQL REL_X_Y for Windows" exists anywhere.
-            #
-            # This may not be available if pgSRCversion is 'RC' or 'BETA'.
-            # pgWINversion: x.y-z
-            # This may not be available if pgSRCversion is 'RC' or 'BETA'.
-            # MSYS2testonpgWIN: true
-            pgWINversion: 17.5-1
-            MSYS2testonpgWIN: true
-
 
           # R latest and PostgreSQL latest (buildpgFromSRCmethod meson)
-          - matid: 9
-            os: windows-latest
+          - matid: 08
+            os: windows-2025
             GithubActionsIgnoreFail: false
             compilerEnv: UCRT64
             shellEnv: msys2 {0}
@@ -288,23 +259,48 @@ jobs:
             Platform: x64
             Configuration: Release
             #
-            rversion: 4.5.0
-            R_HOME: 'D:\RINSTALL'
+            rversion: 4.5.1
+            R_HOME: 'C:\RINSTALL'
             R_ARCH: /x64
             #
             pgSRCversion: REL_17_STABLE
-            PG_SOURCE: 'D:\PGSOURCE'
+            PG_SOURCE: 'C:\PGSOURCE'
             buildpgFromSRC: true
             buildpgFromSRCmethod: meson
-            PG_HOME: 'D:\PGINSTALL'
+            PG_HOME: 'C:\PGINSTALL'
             #
-            pgWINversion: 17.5-1
+            # Note, BELOW Github Actions has installed a lower version (17.5),
+            # than what is available at EnterpriseDB 17.6-1 (Aug 19 2025)
+            #
+            # pgWINversion: 17.5-1
             MSYS2testonpgWIN: true
 
 
-          # R latest and PostgreSQL latest (buildpgANDplrInSRCcontrib true)
+          - matid: 09
+            os: windows-2025
+            GithubActionsIgnoreFail: false
+            compilerEnv: UCRT64
+            shellEnv: msys2 {0}
+            compilerExe: gcc
+            Platform: x64
+            Configuration: Release
+            #
+            rversion: 4.5.1
+            R_HOME: 'C:\RINSTALL'
+            R_ARCH: /x64
+            #
+            pgSRCversion: REL_16_STABLE
+            PG_SOURCE: 'C:\PGSOURCE'
+            buildpgFromSRC: true
+            buildpgFromSRCmethod: meson
+            PG_HOME: 'C:\PGINSTALL'
+            #
+            pgWINversion: 16.10-1
+            MSYS2testonpgWIN: true
+
+
           - matid: 10
-            os: windows-latest
+            os: windows-2025
             GithubActionsIgnoreFail: false
             compilerEnv: UCRT64
             shellEnv: msys2 {0}
@@ -312,21 +308,22 @@ jobs:
             Platform: x64
             Configuration: Release
             #
-            rversion: 4.5.0
-            R_HOME: 'D:\RINSTALL'
+            rversion: 4.5.1
+            R_HOME: 'C:\RINSTALL'
             R_ARCH: /x64
             #
-            pgSRCversion: REL_17_STABLE
-            PG_SOURCE: 'D:\PGSOURCE'
-            buildpgANDplrInSRCcontrib: true
-            PG_HOME: 'D:\PGINSTALL'
+            pgSRCversion: REL_15_STABLE
+            PG_SOURCE: 'C:\PGSOURCE'
+            buildpgFromSRC: true
+            buildpgFromSRCmethod: make
+            PG_HOME: 'C:\PGINSTALL'
             #
-            pgWINversion: 17.5-1
+            pgWINversion: 15.14-1
             MSYS2testonpgWIN: true
 
 
           - matid: 11
-            os: windows-latest
+            os: windows-2025
             GithubActionsIgnoreFail: false
             compilerEnv: UCRT64
             shellEnv: msys2 {0}
@@ -334,73 +331,29 @@ jobs:
             Platform: x64
             Configuration: Release
             #
-            rversion: 4.5.0
-            R_HOME: 'D:\RINSTALL'
-            R_ARCH: /x64
-            #
-            pgSRCversion: REL_16_STABLE
-            PG_SOURCE: 'D:\PGSOURCE'
-            buildpgANDplrInSRCcontrib: true
-            PG_HOME: 'D:\PGINSTALL'
-            #
-            pgWINversion: 16.9-1
-            MSYS2testonpgWIN: true
-
-
-          - matid: 12
-            os: windows-latest
-            GithubActionsIgnoreFail: false
-            compilerEnv: UCRT64
-            shellEnv: msys2 {0}
-            compilerExe: gcc
-            Platform: x64
-            Configuration: Release
-            #
-            rversion: 4.5.0
-            R_HOME: 'D:\RINSTALL'
-            R_ARCH: /x64
-            #
-            pgSRCversion: REL_15_STABLE
-            PG_SOURCE: 'D:\PGSOURCE'
-            buildpgFromSRC: true
-            buildpgFromSRCmethod: make
-            PG_HOME: 'D:\PGINSTALL'
-            #
-            pgWINversion: 15.13-1
-            MSYS2testonpgWIN: true
-
-
-          - matid: 13
-            os: windows-latest
-            GithubActionsIgnoreFail: false
-            compilerEnv: UCRT64
-            shellEnv: msys2 {0}
-            compilerExe: gcc
-            Platform: x64
-            Configuration: Release
-            #
-            rversion: 4.5.0
-            R_HOME: 'D:\RINSTALL'
+            rversion: 4.5.1
+            R_HOME: 'C:\RINSTALL'
             R_ARCH: /x64
             #
             pgSRCversion: REL_14_STABLE
-            PG_SOURCE: 'D:\PGSOURCE'
+            PG_SOURCE: 'C:\PGSOURCE'
             buildpgFromSRC: true
             buildpgFromSRCmethod: make
-            PG_HOME: 'D:\PGINSTALL'
+            PG_HOME: 'C:\PGINSTALL'
             #
             # EnterpriseDB PostgreSQL for Windows
-            # pgWINversion: 14.x-y
+            # windows-2022 and pgWINversion: 14.x-y
             # (if MANUAL would be: 14.18)
             #
-            # A HUMAN must manually see the VERSION here. (seen Jul 13 2024 EST)
-            # Jul 2024 - Pre-installed Github Actions PostgreSQL for Windows version is x64-14
+            # A HUMAN must manually see the VERSION here. (seen Aug 17 2024 EST)
+            # Aug 2025 - Pre-installed Github Actions PostgreSQL for Windows version is x64-14
             # ServiceName postgresql-x64-14
-            # Version 14.12
-            # REAFFIRMED SEP 29 2024
+            # Version 14.18
+            # REAFFIRMED AUG 17 2025
             # https://github.com/actions/runner-images/blob/main/images/windows/Windows2022-Readme.md
             # https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-software
             #
+            pgWINversion: 14.19-1
             MSYS2testonpgWIN: true
 
     defaults:
@@ -410,7 +363,7 @@ jobs:
     steps:
 
       - name: Windows Machine Stats systeminfo
-        if: ${{ matrix.os == 'windows-latest' }}
+        if: ${{ matrix.os == 'windows-2025' }}
         shell: cmd
         run: |
           systeminfo
@@ -422,16 +375,16 @@ jobs:
           git config --global advice.detachedHead false
 
       - name: Matrix Variables
-        if: matrix.os == 'windows-latest'
+        if: matrix.os == 'windows-2025'
         shell: powershell
         run: |
           # systeminfo
           echo "${{ matrix.compilerEnv }} on ${{ matrix.os }}"
-          # JUL 2023 - only THIS exists in Github Actions
-          if( Test-Path "C:\Program Files\PostgreSQL\14" ) {
-            "PostgreSQL for Windows x64-14 exists."
+          # AUG 2025 - THIS exists in Github Actions
+          if( Test-Path "C:\Program Files\PostgreSQL\17" ) {
+            "PostgreSQL for Windows x64-17 exists."
           } else {
-            "PostgreSQL for Windows x64-14 does not exist."
+            "PostgreSQL for Windows x64-17 does not exist."
           }
           function Set-EnvVar {param($X)     Add-Content -Path ${env:GITHUB_ENV} -Value "$X"}
           #
@@ -640,7 +593,7 @@ jobs:
           if("${env:pgWINversion}" -eq "notset") {
             if("${env:pgWINServiceNameHostDefault}" -match "(\d+[.]{0,1}\d+$)") {
               # if (1) no entry "pgWINversion: whatever" and yes entry "MSYS2testonpgWIN: true"
-              # then THIS(14) is the default TESTING(14) "MSYS2testonpgWIN PostgreSQL"
+              # then THIS(17) is the default TESTING(17) "MSYS2testonpgWIN PostgreSQL"
               # 9.6
               # 13
               ${env:pgwinmajor} = $matches[1]; $matches = @()
@@ -727,7 +680,7 @@ jobs:
 
 
       - name: Matrix Windows Platform Specific Variables
-        if: ${{ env.os == 'windows-latest' && ( env.compilerClass == 'MSYS2' || env.compilerClass == 'msvc' ) }}
+        if: ${{ env.os == 'windows-2025' && ( env.compilerClass == 'MSYS2' || env.compilerClass == 'msvc' ) }}
         shell: powershell
         run: |
           function Set-EnvVar {param($X)     Add-Content -Path ${env:GITHUB_ENV} -Value "$X"}
@@ -769,7 +722,7 @@ jobs:
           echo "CRAN_R_DOWNLOAD_URL: ${env:CRAN_R_DOWNLOAD_URL}"
 
       - name: Checkout Code of This Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       # running Meson on GitHub Actions will end up using GCC rather than MSVC
       #
@@ -779,7 +732,7 @@ jobs:
       # `x64` for 64-bit x86 machines, `x86` for 32-bit x86 machines.
       # https://github.com/bus1/cabuild/blob/8c91ebf06b7a5f8405cf93c89a6928e4c76967e0/action/msdevshell/action.yml
       - name: Prepare Github Actions, MSVC, and Meson
-        if: ${{ env.os == 'windows-latest' && env.compilerClass == 'msvc' }}
+        if: ${{ env.os == 'windows-2025' && env.compilerClass == 'msvc' }}
         uses: bus1/cabuild/action/msdevshell@v1
         with:
           # msvc ARCHITECTURE
@@ -787,7 +740,7 @@ jobs:
 
       - name: Checkout PostgreSQL Code
         if: ${{ env.pgSRCversion != 'notset' }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: 'postgres/postgres'
 
@@ -814,7 +767,7 @@ jobs:
           path: PGSOURCE
 
       - name: Windows Move PostgreSQL Code
-        if: ${{ env.os == 'windows-latest' && env.pgSRCversion != 'notset' }}
+        if: ${{ env.os == 'windows-2025' && env.pgSRCversion != 'notset' }}
         shell: powershell
         run: |
           Copy-Item -Path PGSOURCE -Destination ${{ env.PG_SOURCE }} -Recurse -Force
@@ -829,7 +782,7 @@ jobs:
       # https://github.com/actions/cache/blob/main/tips-and-workarounds.md#update-a-cache
       #
       - name: Cache R-x.y.z Windows Installer Exe
-        if: ${{ env.os == 'windows-latest' && ( env.compilerClass == 'MSYS2' || env.compilerClass == 'msvc' ) && env.rversion != 'devel' }}
+        if: ${{ env.os == 'windows-2025' && ( env.compilerClass == 'MSYS2' || env.compilerClass == 'msvc' ) && env.rversion != 'devel' }}
         uses: actions/cache@v4
         id: cacheRWindowsInstallerExe
         with:
@@ -840,8 +793,8 @@ jobs:
 
       - name: Cache PostgreSQL for Windows
         if: >-
-          ${{ env.os == 'windows-latest' && ( env.compilerClass == 'MSYS2' || env.compilerClass == 'msvc' ) && env.pgWINversion != 'notset' &&
-          (( env.PGVER2 == '14' && env.Platform == 'x86' ) || ( env.PGVER2 != '14' ))
+          ${{ env.os == 'windows-2025' && ( env.compilerClass == 'MSYS2' || env.compilerClass == 'msvc' ) && env.pgWINversion != 'notset' &&
+          (( env.PGVER2 == '17' && env.Platform == 'x86' ) || ( env.PGVER2 != '17' ))
           }}
         uses: actions/cache@v4
         id: cachePGWindowsInstallerExe
@@ -852,7 +805,7 @@ jobs:
           SEGMENT_DOWNLOAD_TIMEOUT_MINS: 10
 
       - name: Cache GNU diffutils for Test on PostgreSQL for Windows
-        if: ${{ ( env.os == 'windows-latest' && env.compilerClass == 'MSYS2' && env.MSYS2testonpgWIN == 'true' ) || ( env.os == 'windows-latest' && env.compilerClass == 'msvc' ) }}
+        if: ${{ ( env.os == 'windows-2025' && env.compilerClass == 'MSYS2' && env.MSYS2testonpgWIN == 'true' ) || ( env.os == 'windows-2025' && env.compilerClass == 'msvc' ) }}
         uses: actions/cache@v4
         id: cacheDiffutilsZip
         with:
@@ -862,7 +815,7 @@ jobs:
           SEGMENT_DOWNLOAD_TIMEOUT_MINS: 1
 
       - name: Cache pkgconfiglite for Compile using msvc and meson
-        if: ${{ env.os == 'windows-latest' && env.compilerClass == 'msvc' }}
+        if: ${{ env.os == 'windows-2025' && env.compilerClass == 'msvc' }}
         uses: actions/cache@v4
         id: cachePkgConfigLiteZip
         with:
@@ -872,7 +825,7 @@ jobs:
           SEGMENT_DOWNLOAD_TIMEOUT_MINS: 1
 
       - name: Cache winflexbison for Compile using msvc
-        if: ${{ env.os == 'windows-latest' && env.compilerClass == 'msvc' }}
+        if: ${{ env.os == 'windows-2025' && env.compilerClass == 'msvc' }}
         uses: actions/cache@v4
         id: cacheWinFlexBisonZip
         with:
@@ -882,7 +835,7 @@ jobs:
           SEGMENT_DOWNLOAD_TIMEOUT_MINS: 1
 
       - name: Cache meson for Compile using msvc and meson
-        if: ${{ env.os == 'windows-latest' && env.compilerClass == 'msvc' }}
+        if: ${{ env.os == 'windows-2025' && env.compilerClass == 'msvc' }}
         uses: actions/cache@v4
         id: cacheMesonMsi
         with:
@@ -892,7 +845,7 @@ jobs:
           SEGMENT_DOWNLOAD_TIMEOUT_MINS: 1
 
       - name: Cache StrawberryPerl
-        if: ${{ env.os == 'windows-latest' && env.compilerClass == 'MSYS2' && env.compilerEnv == 'MINGW32' }}
+        if: ${{ env.os == 'windows-2025' && env.compilerClass == 'MSYS2' && env.compilerEnv == 'MINGW32' }}
         uses: actions/cache@v4
         id: cacheStrawberryPerlMsi
         with:
@@ -912,7 +865,7 @@ jobs:
       # five seconds
       - name: Download R for Windows R-x.y.z R-rmajor.rminor.rpatch
         if: >-
-          ${{ env.os == 'windows-latest' && ( env.compilerClass == 'MSYS2' || env.compilerClass == 'msvc' ) &&
+          ${{ env.os == 'windows-2025' && ( env.compilerClass == 'MSYS2' || env.compilerClass == 'msvc' ) &&
           steps.cacheRWindowsInstallerExe.outputs.cache-hit != 'true'
           }}
         uses: suisei-cn/actions-download-file@v1.6.0
@@ -922,8 +875,8 @@ jobs:
 
       - name: Download PostgreSQL for Windows
         if: >-
-          ${{ env.os == 'windows-latest' && ( env.compilerClass == 'MSYS2' || env.compilerClass == 'msvc' ) && env.pgWINversion != 'notset' &&
-          (( env.PGVER2 == '14' && env.Platform == 'x86' ) || ( env.PGVER2 != '14' )) &&
+          ${{ env.os == 'windows-2025' && ( env.compilerClass == 'MSYS2' || env.compilerClass == 'msvc' ) && env.pgWINversion != 'notset' &&
+          (( env.PGVER2 == '17' && env.Platform == 'x86' ) || ( env.PGVER2 != '17' )) &&
           steps.cachePGWindowsInstallerExe.outputs.cache-hit != 'true'
           }}
         uses: suisei-cn/actions-download-file@v1.6.0
@@ -938,7 +891,7 @@ jobs:
 #         args: install diffutils
 
       - name: Download GNU diffutils for Test on PostgreSQL for Windows
-        if: ${{ ( ( env.os == 'windows-latest' && env.compilerClass == 'MSYS2' && env.MSYS2testonpgWIN == 'true' ) || ( env.os == 'windows-latest' && env.compilerClass == 'msvc' ) ) &&
+        if: ${{ ( ( env.os == 'windows-2025' && env.compilerClass == 'MSYS2' && env.MSYS2testonpgWIN == 'true' ) || ( env.os == 'windows-2025' && env.compilerClass == 'msvc' ) ) &&
           steps.cacheDiffutilsZip.outputs.cache-hit != 'true'
           }}
         uses: suisei-cn/actions-download-file@v1.6.0
@@ -951,7 +904,7 @@ jobs:
 
       - name: Download pkgconfiglite for Compile using msvc and meson
         if: >-
-          ${{ env.os == 'windows-latest' && env.compilerClass == 'msvc' &&
+          ${{ env.os == 'windows-2025' && env.compilerClass == 'msvc' &&
           steps.cachePkgConfigLiteZip.outputs.cache-hit != 'true'
           }}
         uses: suisei-cn/actions-download-file@v1.6.0
@@ -964,7 +917,7 @@ jobs:
 
       - name: Download winflexbison for Compile using msvc
         if: >-
-          ${{ env.os == 'windows-latest' && env.compilerClass == 'msvc' &&
+          ${{ env.os == 'windows-2025' && env.compilerClass == 'msvc' &&
           steps.cacheWinFlexBisonZip.outputs.cache-hit != 'true'
           }}
         uses: suisei-cn/actions-download-file@v1.6.0
@@ -977,7 +930,7 @@ jobs:
 
       - name: Download meson for Compile using msvc and meson
         if: >-
-          ${{ env.os == 'windows-latest' && env.compilerClass == 'msvc' &&
+          ${{ env.os == 'windows-2025' && env.compilerClass == 'msvc' &&
           steps.cacheMesonMsi.outputs.cache-hit != 'true'
           }}
         uses: suisei-cn/actions-download-file@v1.6.0
@@ -995,7 +948,7 @@ jobs:
 
       - name: Download StrawberryPerl
         if: >-
-          ${{ env.os == 'windows-latest' && env.compilerClass == 'MSYS2' && env.compilerEnv == 'MINGW32' &&
+          ${{ env.os == 'windows-2025' && env.compilerClass == 'MSYS2' && env.compilerEnv == 'MINGW32' &&
           steps.cacheStrawberryPerlMsi.outputs.cache-hit != 'true'
           }}
         uses: suisei-cn/actions-download-file@v1.6.0
@@ -1009,7 +962,7 @@ jobs:
           url: https://github.com/StrawberryPerl/Perl-Dist-Strawberry/releases/download/SP_53822_64bit/strawberry-perl-5.38.2.2-64bit.msi
 
       - name: Install R for Windows R-x.y.z R-rmajor.rminor.rpatch
-        if: ${{ env.os == 'windows-latest' && ( env.compilerClass == 'MSYS2' || env.compilerClass == 'msvc' ) }}
+        if: ${{ env.os == 'windows-2025' && ( env.compilerClass == 'MSYS2' || env.compilerClass == 'msvc' ) }}
         env:
           R_HOME: ${{ env.R_HOME }}
           R_ARCHplat: ${{ env.R_ARCHplat }}
@@ -1024,40 +977,39 @@ jobs:
           "${{ env.rversionlong }}.exe" /VERYSILENT /COMPONENTS=main,%R_ARCHplat% /DIR=%R_HOME% /NOICONS /TASKS=
           dir "%R_HOME%"
 
-      # Github Actions provided PostgreSQL x64-14 (as of Jul 2024)
+      # Github Actions provided PostgreSQL x64-17 (as of Aug 2025)
       #
-      # # Jul 2024
-      # # The PL/R extension was built using PostreSQL 15
-      # ServiceName postgresql-x64-14
-      # Version 14.12
+      # # Aug 2025
+      # ServiceName postgresql-x64-17
+      # Version 17.5
       # ServiceStatus Stopped
       # ServiceStartType Disabled
-      # EnvironmentVariables PGBIN=C:\Program Files\PostgreSQL\14\bin
-      # PGDATA=C:\Program Files\PostgreSQL\14\data
-      # PGROOT=C:\Program Files\PostgreSQL\14
-      # Path C:\Program Files\PostgreSQL\14
+      # EnvironmentVariables PGBIN=C:\Program Files\PostgreSQL\17\bin
+      # PGDATA=C:\Program Files\PostgreSQL\17\data
+      # PGROOT=C:\Program Files\PostgreSQL\17
+      # Path C:\Program Files\PostgreSQL\17
       # UserName postgres
       # Password root
       # #
-      # https://github.com/actions/runner-images/blob/main/images/windows/Windows2022-Readme.md
+      # https://github.com/actions/runner-images/blob/main/images/windows/Windows2025-Readme.md
       # https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-software
       #
-      - name: From Disabled, Enable PostgreSQL x64-14 for Windows and Start and Stop
+      - name: From Disabled, Enable PostgreSQL x64-17 for Windows and Start and Stop
         if: >-
-          ${{ env.os == 'windows-latest' && ( env.compilerClass == 'MSYS2' && env.MSYS2testonpgWIN == 'true' || env.compilerClass == 'msvc' ) &&
-          env.PGVER2 == '14' && env.Platform == 'x64'
+          ${{ env.os == 'windows-2025' && ( env.compilerClass == 'MSYS2' && env.MSYS2testonpgWIN == 'true' || env.compilerClass == 'msvc' ) &&
+          env.PGVER2 == '17' && env.Platform == 'x64'
           }}
         shell: cmd
         run: |
           echo on
-          sc config "postgresql-x64-14" start= auto
-          net start  postgresql-x64-14
-          net stop   postgresql-x64-14
+          sc config "postgresql-x64-17" start= auto
+          net start  postgresql-x64-17
+          net stop   postgresql-x64-17
 
       - name: Install PostgreSQL for Windows and Stop PostgreSQL
         if: >-
-          ${{ env.os == 'windows-latest' && ( env.compilerClass == 'MSYS2' || env.compilerClass == 'msvc' ) && env.pgWINversion != 'notset' &&
-          (( env.PGVER2 == '14' && env.Platform == 'x86' ) || ( env.PGVER2 != '14' ))
+          ${{ env.os == 'windows-2025' && ( env.compilerClass == 'MSYS2' || env.compilerClass == 'msvc' ) && env.pgWINversion != 'notset' &&
+          (( env.PGVER2 == '17' && env.Platform == 'x86' ) || ( env.PGVER2 != '17' ))
           }}
         env:
           PGVER2: ${{ env.PGVER2 }}
@@ -1097,7 +1049,7 @@ jobs:
       #   NOTE - meson - fails with msiexec.exe Exit code was '3010' (see OTHER step)
       #   NOTE - 7z is provided by Github Actions
       - name: Choco Install support software about PL/R compiling using msvc for Windows
-        if: ${{ env.os == 'windows-latest' && env.compilerClass == 'msvc' }}
+        if: ${{ env.os == 'windows-2025' && env.compilerClass == 'msvc' }}
         # Keep v2.  v2.2.0 may have connection to Sourceforge problems
         uses: crazy-max/ghaction-chocolatey@v3
         with:
@@ -1108,7 +1060,7 @@ jobs:
       # Choco Install GNU diffutils
       # BUT the "crazy-max/ghaction-chocolatey@v2" "install diffutils" file download often times-out
       - name: Extract Diffuntils and add Diffuntils bin directory to the PATH for Test on PostgreSQL for Windows
-        if: ${{ ( env.os == 'windows-latest' && env.compilerClass == 'MSYS2' && env.MSYS2testonpgWIN == 'true' ) || ( env.os == 'windows-latest' && env.compilerClass == 'msvc' ) }}
+        if: ${{ ( env.os == 'windows-2025' && env.compilerClass == 'MSYS2' && env.MSYS2testonpgWIN == 'true' ) || ( env.os == 'windows-2025' && env.compilerClass == 'msvc' ) }}
         shell: cmd
         run: |
           rem MKDIR creates any intermediate directories in the path, if needed.
@@ -1123,7 +1075,7 @@ jobs:
       # Choco Install pkgconfiglite
       # BUT the "crazy-max/ghaction-chocolatey@v2" "install pkgconfiglite" file download often times-out
       - name: Extract pkgconfiglite and add pkgconfiglite bin directory to the PATH for Compile using msvc and meson
-        if: ${{ env.os == 'windows-latest' && env.compilerClass == 'msvc' }}
+        if: ${{ env.os == 'windows-2025' && env.compilerClass == 'msvc' }}
         shell: cmd
         run: |
           rem MKDIR creates any intermediate directories in the path, if needed.
@@ -1138,7 +1090,7 @@ jobs:
       # Choco Install winflexbison
       # BUT the "crazy-max/ghaction-chocolatey@v2" "install pkgconfiglite" file download often times-out
       - name: Extract winflexbison and add the winflexbison directory to the PATH for Compile using msvc
-        if: ${{ env.os == 'windows-latest' && env.compilerClass == 'msvc' }}
+        if: ${{ env.os == 'windows-2025' && env.compilerClass == 'msvc' }}
         shell: cmd
         run: |
           rem MKDIR creates any intermediate directories in the path, if needed.
@@ -1153,7 +1105,7 @@ jobs:
       # Choco Install meson
       # BUT the "crazy-max/ghaction-chocolatey@v3" "install meson" msiexec.exe Exit code was '3010'.
       - name: Install meson and add meson directory to the PATH for Compile using msvc and meson
-        if: ${{ env.os == 'windows-latest' && env.compilerClass == 'msvc' }}
+        if: ${{ env.os == 'windows-2025' && env.compilerClass == 'msvc' }}
         shell: cmd
         run: |
           msiexec.exe /i meson-1.4.1-64.msi /qn /norestart /l*v meson.1.4.1.MsiInstall.log
@@ -1161,7 +1113,7 @@ jobs:
           type meson.1.4.1.MsiInstall.log
 
       - name: Install Strawberry Perl
-        if: ${{ env.os == 'windows-latest' && env.compilerClass == 'MSYS2' && env.compilerEnv == 'MINGW32' }}
+        if: ${{ env.os == 'windows-2025' && env.compilerClass == 'MSYS2' && env.compilerEnv == 'MINGW32' }}
         shell: cmd
         run: |
           msiexec.exe /i strawberry-perl-5.38.2.2-64bit.msi /qn /norestart /l*v strawberry-perl-5.38.2.2-64bit.msiInstall.log
@@ -1171,7 +1123,7 @@ jobs:
       # 34 seconds with zero packages
       # 2 minutes and seven(7) seconds with everything
       - name: Install Windows mingw Software
-        if: ${{ env.os == 'windows-latest' && env.compilerClass == 'MSYS2' && env.compilerEnv != 'MINGW32' }}
+        if: ${{ env.os == 'windows-2025' && env.compilerClass == 'MSYS2' && env.compilerEnv != 'MINGW32' }}
         uses: msys2/setup-msys2@v2
         with:
           # By default, the installation is not updated; hence package versions are those of the installation tarball.
@@ -1214,7 +1166,7 @@ jobs:
       # 34 seconds with zero packages
       # 2 minutes and seven(7) seconds with everything
       - name: Install Windows mingw Software - same as above - but omit software - perl winpty
-        if: ${{ env.os == 'windows-latest' && env.compilerClass == 'MSYS2' && env.compilerEnv == 'MINGW32' }}
+        if: ${{ env.os == 'windows-2025' && env.compilerClass == 'MSYS2' && env.compilerEnv == 'MINGW32' }}
         uses: msys2/setup-msys2@v2
         with:
           # By default, the installation is not updated; hence package versions are those of the installation tarball.
@@ -1254,7 +1206,7 @@ jobs:
 
 
       - name: Install Windows mingw Software Repository PostgreSQL
-        if: ${{ env.os == 'windows-latest' && env.compilerClass == 'MSYS2' && env.buildpgFromSRC != 'true' }}
+        if: ${{ env.os == 'windows-2025' && env.compilerClass == 'MSYS2' && env.buildpgFromSRC != 'true' }}
         env:
           # Msys OS variable
           msystem: ${{ env.compilerEnv }}
@@ -1264,14 +1216,16 @@ jobs:
           pacman -S --needed --noconfirm ${{ env.MINGW_PACKAGE_PREFIX }}-postgresql
 
       - name: Set up Cygwin
-        if: ${{ env.os == 'windows-latest' && env.compilerClass == 'cygwin' }}
-        uses: cygwin/cygwin-install-action@v5
+        if: ${{ env.os == 'windows-2025' && env.compilerClass == 'cygwin' }}
+        uses: cygwin/cygwin-install-action@v6
         with:
           # x86 or x86_64
           #         GitHub offers ternary operator like behaviour that you can use in expressions
           platform: ${{ env.Platform == 'x64' && 'x86_64' || 'x86' }}
+          install-dir: 'C:\cygwin'
           # REQUIRED def true - otherwise the default install MING64 "bash" will be found
           # add-to-path: true
+          work-vol: 'C:'
           packages: >-
              cygrunsrv pkg-config  meson  gendef
              gcc-core  make  tar  gzip  libreadline7  zlib  icu-devel  bison  perl
@@ -1284,7 +1238,7 @@ jobs:
 
       # If the PostgreSQL version is 16 or greater, I can compile PostgreSQL using meson.
       - name: Compile PG using pgSRCversion and PG_SOURCE and Install to here PG_HOME
-        if: ${{ env.os == 'windows-latest' && ( env.compilerClass == 'MSYS2' || env.compilerClass == 'cygwin' ) && env.buildpgFromSRC == 'true' }}
+        if: ${{ env.os == 'windows-2025' && ( env.compilerClass == 'MSYS2' || env.compilerClass == 'cygwin' ) && env.buildpgFromSRC == 'true' }}
         env:
           # Cygwin OS variables
           SHELLOPTS: igncr
@@ -1441,7 +1395,7 @@ jobs:
           fi
 
       - name: Windows Prep PG Artifact
-        if: ${{ env.os == 'windows-latest' && env.compilerClass == 'MSYS2' && env.buildpgFromSRC == 'true' }}
+        if: ${{ env.os == 'windows-2025' && env.compilerClass == 'MSYS2' && env.buildpgFromSRC == 'true' }}
         env:
           PGVER2: ${{ env.PGVER2 }}
           Platform: ${{ env.Platform }}
@@ -1449,8 +1403,8 @@ jobs:
         run: |
           echo on
           dir
-          if exist pg-artifact.7z copy pg-artifact.7z pg-matid-${{ matrix.matid }}-${{ env.os }}-${{ env.compilerEnv }}-${{ env.Platform }}-PG${{ env.pgversion }}-${{ env.Configuration }}-R${{ env.rversion }}-PGSRC${{ env.buildpgFromSRC }}-PGSRCMETH${{ env.buildpgFromSRCmethod }}-SRCCTB${{ env.buildpgANDplrInSRCcontrib }}.7z
-          if exist pg-artifact.7z dir                 pg-matid-${{ matrix.matid }}-${{ env.os }}-${{ env.compilerEnv }}-${{ env.Platform }}-PG${{ env.pgversion }}-${{ env.Configuration }}-R${{ env.rversion }}-PGSRC${{ env.buildpgFromSRC }}-PGSRCMETH${{ env.buildpgFromSRCmethod }}-SRCCTB${{ env.buildpgANDplrInSRCcontrib }}.7z
+          if exist pg-artifact.7z copy pg-artifact.7z pg-matid-${{ matrix.matid }}-${{ env.compilerEnv }}-${{ env.Platform }}-PG${{ env.pgversion }}-${{ env.Configuration }}-R${{ env.rversion }}-PGSRC${{ env.buildpgFromSRC }}-PGSRCMETH${{ env.buildpgFromSRCmethod }}-SRCCTB${{ env.buildpgANDplrInSRCcontrib }}.7z
+          if exist pg-artifact.7z dir                 pg-matid-${{ matrix.matid }}-${{ env.compilerEnv }}-${{ env.Platform }}-PG${{ env.pgversion }}-${{ env.Configuration }}-R${{ env.rversion }}-PGSRC${{ env.buildpgFromSRC }}-PGSRCMETH${{ env.buildpgFromSRCmethod }}-SRCCTB${{ env.buildpgANDplrInSRCcontrib }}.7z
 
       # @v4 - Due to how Artifacts are created in this new version,
       # it is no longer possible to upload to the same named Artifact multiple times.
@@ -1458,15 +1412,15 @@ jobs:
       # github.com/actions/upload-artifact
       #
       - name: Upload artifact PG for export for LOCAL testing
-        if: ${{ env.os == 'windows-latest' &&  env.compilerClass == 'MSYS2' && env.buildpgFromSRC == 'true' }}
+        if: ${{ env.os == 'windows-2025' &&  env.compilerClass == 'MSYS2' && env.buildpgFromSRC == 'true' }}
         uses: actions/upload-artifact@v4
         with:
-          name: pg-matid-${{ matrix.matid }}-${{ env.os }}-${{ env.compilerEnv }}-${{ env.Platform }}-PG${{ env.pgversion }}-${{ env.Configuration }}-R${{ env.rversion }}-PGSRC${{ env.buildpgFromSRC }}-PGSRCMETH${{ env.buildpgFromSRCmethod }}-SRCCTB${{ env.buildpgANDplrInSRCcontrib }}
+          name: pg-matid-${{ matrix.matid }}-${{ env.compilerEnv }}-${{ env.Platform }}-PG${{ env.pgversion }}-${{ env.Configuration }}-R${{ env.rversion }}-PGSRC${{ env.buildpgFromSRC }}-PGSRCMETH${{ env.buildpgFromSRCmethod }}-SRCCTB${{ env.buildpgANDplrInSRCcontrib }}
           path: |
-            pg-matid-${{ matrix.matid }}-${{ env.os }}-${{ env.compilerEnv }}-${{ env.Platform }}-PG${{ env.pgversion }}-${{ env.Configuration }}-R${{ env.rversion }}-PGSRC${{ env.buildpgFromSRC }}-PGSRCMETH${{ env.buildpgFromSRCmethod }}-SRCCTB${{ env.buildpgANDplrInSRCcontrib }}.7z
+            pg-matid-${{ matrix.matid }}-${{ env.compilerEnv }}-${{ env.Platform }}-PG${{ env.pgversion }}-${{ env.Configuration }}-R${{ env.rversion }}-PGSRC${{ env.buildpgFromSRC }}-PGSRCMETH${{ env.buildpgFromSRCmethod }}-SRCCTB${{ env.buildpgANDplrInSRCcontrib }}.7z
 
       - name: Windows non-msvc Meson PG and Meson PL/R Setup Compile and Non-Meson Manual Test
-        if: ${{ env.os == 'windows-latest' && ( env.compilerClass == 'MSYS2' || env.compilerClass == 'cygwin' ) && env.buildpgANDplrInSRCcontrib == 'true' }}
+        if: ${{ env.os == 'windows-2025' && ( env.compilerClass == 'MSYS2' || env.compilerClass == 'cygwin' ) && env.buildpgANDplrInSRCcontrib == 'true' }}
         env:
           # Cygwin shell variables
           SHELLOPTS: igncr
@@ -1969,7 +1923,7 @@ jobs:
 
           # meson has no "test" pre-req system.  So this "ordered" implentation is a kind of "hack".
           # sometimes the "plr" regression test fails if an "easier" regression test did not come before it.
-          # true - cube failed its regression test and blocked plr - R devel PGsrc REL_17_BETA2 PGbin UCRT64 x64 windows-latest Debug
+          # true - cube failed its regression test and blocked plr - R devel PGsrc REL_17_BETA2 PGbin UCRT64 x64 windows-2025 Debug
 
           # classic of 2023 and pg16
           # meson test -C build --num-processes 1 -v --suite setup --suite cube
@@ -2051,7 +2005,7 @@ jobs:
           fi
 
       - name: Windows non-msvc Meson PL/R Setup Compile and Non-Meson Manual Test
-        if: ${{ env.os == 'windows-latest' && ( env.compilerClass == 'MSYS2' || env.compilerClass == 'cygwin' ) && env.buildpgANDplrInSRCcontrib != 'true' }}
+        if: ${{ env.os == 'windows-2025' && ( env.compilerClass == 'MSYS2' || env.compilerClass == 'cygwin' ) && env.buildpgANDplrInSRCcontrib != 'true' }}
         env:
           # Cygwin shell variables
           SHELLOPTS: igncr
@@ -2633,7 +2587,7 @@ jobs:
           fi
 
       - name: Windows     msvc Meson PL/R Setup Compile and Non-Meson Manual Test
-        if: ${{ env.os == 'windows-latest' && env.compilerClass == 'msvc' }}
+        if: ${{ env.os == 'windows-2025' && env.compilerClass == 'msvc' }}
         env:
           R_HOME: ${{ env.R_HOME }}
           Platform: ${{ env.Platform }}
@@ -2686,7 +2640,7 @@ jobs:
         if: ${{ always() }}
         uses: actions/upload-artifact@v4
         with:
-          name: plr-matid-${{ matrix.matid }}-${{ env.HEAD8_GITHUB_SHA }}-${{ env.os }}-${{ env.compilerEnv }}-${{ env.Platform }}-R${{ env.rversion }}-PG${{ env.pgversion }}-${{ env.Configuration }}
+          name: plr-matid-${{ matrix.matid }}-${{ env.HEAD8_GITHUB_SHA }}-${{ env.compilerEnv }}-${{ env.Platform }}-R${{ env.rversion }}-PG${{ env.pgversion }}-${{ env.Configuration }}
           # default
           if-no-files-found: warn
           path: |
@@ -2694,7 +2648,7 @@ jobs:
             tmp\PLR_LICENSE
 
       - name: Set R_HOME and PG PATH, Start PG(read OS variables), Test on PostgreSQL for Windows
-        if: ${{ env.os == 'windows-latest' && env.compilerClass == 'MSYS2' && env.MSYS2testonpgWIN == 'true' }}
+        if: ${{ env.os == 'windows-2025' && env.compilerClass == 'MSYS2' && env.MSYS2testonpgWIN == 'true' }}
         env:
           R_HOME: ${{ env.R_HOME }}
           R_ARCH: ${{ env.R_ARCH }}
@@ -2755,7 +2709,7 @@ jobs:
           if "%ERRORLEVEL%"=="1" exit 1
 
       - name: Stop PostgreSQL for Windows
-        if: ${{ env.os == 'windows-latest' && env.compilerClass == 'MSYS2' && env.MSYS2testonpgWIN == 'true' }}
+        if: ${{ env.os == 'windows-2025' && env.compilerClass == 'MSYS2' && env.MSYS2testonpgWIN == 'true' }}
         env:
           PGVER2: ${{ env.PGVER2 }}
           Platform: ${{ env.Platform }}
@@ -2770,7 +2724,7 @@ jobs:
           if "%Platform%"=="notset" (echo Platform is not set, therefore no net stop happens.)
 
       - name: Windows Prep PL/R Artifact for Release
-        if: ${{ env.os == 'windows-latest' && ( env.compilerClass == 'MSYS2' || env.compilerClass == 'cygwin' || env.compilerClass == 'msvc' ) }}
+        if: ${{ env.os == 'windows-2025' && ( env.compilerClass == 'MSYS2' || env.compilerClass == 'cygwin' || env.compilerClass == 'msvc' ) }}
         env:
           PGVER2: ${{ env.PGVER2 }}
           Platform: ${{ env.Platform }}
@@ -2778,8 +2732,8 @@ jobs:
         run: |
           echo on
           dir
-          if exist plr-artifact.zip copy plr-artifact.zip plr-matid-${{ matrix.matid }}-${{ env.HEAD8_GITHUB_SHA }}-${{ env.os }}-${{ env.compilerEnv }}-${{ env.Platform }}-R${{ env.rversion }}-PG${{ env.pgversion }}-${{ env.Configuration }}.zip
-          if exist plr-artifact.zip dir                   plr-matid-${{ matrix.matid }}-${{ env.HEAD8_GITHUB_SHA }}-${{ env.os }}-${{ env.compilerEnv }}-${{ env.Platform }}-R${{ env.rversion }}-PG${{ env.pgversion }}-${{ env.Configuration }}.zip
+          if exist plr-artifact.zip copy plr-artifact.zip plr-matid-${{ matrix.matid }}-${{ env.HEAD8_GITHUB_SHA }}-${{ env.compilerEnv }}-${{ env.Platform }}-R${{ env.rversion }}-PG${{ env.pgversion }}-${{ env.Configuration }}.zip
+          if exist plr-artifact.zip dir                   plr-matid-${{ matrix.matid }}-${{ env.HEAD8_GITHUB_SHA }}-${{ env.compilerEnv }}-${{ env.Platform }}-R${{ env.rversion }}-PG${{ env.pgversion }}-${{ env.Configuration }}.zip
 
       # Testing is not done here.
       # Pushing this tag assumes that the previous Github Actions workflow run had all 'successes'.
@@ -2792,5 +2746,5 @@ jobs:
           # "artifacts" means "paths" and "files"
           # set of paths representing artifacts to upload to the release
           artifacts: |
-            plr-matid-${{ matrix.matid }}-${{ env.HEAD8_GITHUB_SHA }}-${{ env.os }}-${{ env.compilerEnv }}-${{ env.Platform }}-R${{ env.rversion }}-PG${{ env.pgversion }}-${{ env.Configuration }}.zip
+            plr-matid-${{ matrix.matid }}-${{ env.HEAD8_GITHUB_SHA }}-${{ env.compilerEnv }}-${{ env.Platform }}-R${{ env.rversion }}-PG${{ env.pgversion }}-${{ env.Configuration }}.zip
           token: ${{ secrets.ACTIONS_CREATE_RELEASE_REPO_SECRET }}

--- a/.github/workflows/buildPLRschedule.yml
+++ b/.github/workflows/buildPLRschedule.yml
@@ -71,7 +71,7 @@ jobs:
 ##          #
 ##          # current Cygwin repository
 ##          - matid: 1
-##            os: windows-latest
+##            os: windows-2025
 ##            GithubActionsIgnoreFail: false
 ##            compilerEnv: cygwin
 ##            Platform: x64
@@ -102,12 +102,12 @@ jobs:
 ##
 ##          # SEEN MAY 2025 (not yet SWITCHING to windows-2025 - need to modify HARDCODED yaml from 14 to 17)
 ##          # windows-2025 (uses PG 17)
-##          # windows-latest or windows-2022 (uses PG 14)
+##          # windows-2025 or windows-2025 (uses PG 14)
 ##          # https://github.com/actions/runner-images
 
           # R bleeding edge and PostgreSQL bleeding edge (buildpgFromSRCmethod meson)
-          - matid: 2
-            os: windows-latest
+          - matid: 02
+            os: windows-2025
             GithubActionsIgnoreFail: false
             compilerEnv: UCRT64
             shellEnv: msys2 {0}
@@ -116,305 +116,15 @@ jobs:
             Configuration: Debug
             #
             rversion:  devel
-            R_HOME: 'D:\RINSTALL'
+            R_HOME: 'C:\RINSTALL'
             R_ARCH: /x64
             #
             pgSRCversion: master
-            PG_SOURCE: 'D:\PGSOURCE'
+            PG_SOURCE: 'C:\PGSOURCE'
             buildpgFromSRC: true
             buildpgFromSRCmethod: meson
-            PG_HOME: 'D:\PGINSTALL'
+            PG_HOME: 'C:\PGINSTALL'
 
-
-##          # R latest and PostgreSQL bleeding edge (buildpgFromSRCmethod meson)
-##          - matid: 3
-##            os: windows-latest
-##            GithubActionsIgnoreFail: true
-##            compilerEnv: UCRT64
-##            shellEnv: msys2 {0}
-##            compilerExe: gcc
-##            Platform: x64
-##            Configuration: Debug
-##            #
-##            rversion: 4.5.0
-##            R_HOME: 'D:\RINSTALL'
-##            R_ARCH: /x64
-##            #
-##            pgSRCversion: master
-##            PG_SOURCE: 'D:\PGSOURCE'
-##            buildpgFromSRC: true
-##            buildpgFromSRCmethod: meson
-##            PG_HOME: 'D:\PGINSTALL'
-##
-##
-##          # R latest and PostgreSQL bleeding edge (buildpgANDplrInSRCcontrib true)
-##          - matid: 4
-##            os: windows-latest
-##            GithubActionsIgnoreFail: true
-##            compilerEnv: UCRT64
-##            shellEnv: msys2 {0}
-##            compilerExe: gcc
-##            Platform: x64
-##            Configuration: Debug
-##            #
-##            rversion: 4.5.0
-##            R_HOME: 'D:\RINSTALL'
-##            R_ARCH: /x64
-##            #
-##            # A HUMAN must manually see the VERSION here. (seen Jul 13 2024 EST)
-##            # Because this is "next PostgreSQL",
-##            # if available are/is 'release candidate' REL_AA_RC#
-##            # and/or 'beta' REL_AA_BETA# version(s)
-##            # then choose that 'latest' version;
-##            # 'REL' is later than 'BETA'. Higher numbers are later than lower numbers.
-##            # Otherwise, just choose the latest REL_XX_Y or better just REL_XX_STABLE
-##            # https://github.com/postgres/postgres/tags
-##            pgSRCversion: master
-##            PG_SOURCE: 'D:\PGSOURCE'
-##            #
-##            # buildpgFromSRC: true
-##            # buildpgFromSRCmethod: make/meson(PostgreSQL 16+)
-##            #   Add meson build system (Andres Freund, Nazir Bilal Yavuz, Peter Eisentraut)
-##            #   https://www.postgresql.org/docs/16/release-16.html
-##            # xor
-##            # buildpgANDplrInSRCcontrib: true
-##            buildpgANDplrInSRCcontrib: true
-##            PG_HOME: 'D:\PGINSTALL'
-##
-##          # R bleeding edge and PostgreSQL latest (buildpgFromSRCmethod meson)
-##          - matid: 5
-##            os: windows-latest
-##            GithubActionsIgnoreFail: true
-##            compilerEnv: UCRT64
-##            shellEnv: msys2 {0}
-##            compilerExe: gcc
-##            Platform: x64
-##            Configuration: Debug
-##            #
-##            rversion:  devel
-##            R_HOME: 'D:\RINSTALL'
-##            R_ARCH: /x64
-##            #
-##            pgSRCversion: REL_18_STABLE
-##            PG_SOURCE: 'D:\PGSOURCE'
-##            buildpgFromSRC: true
-##            buildpgFromSRCmethod: meson
-##            PG_HOME: 'D:\PGINSTALL'
-##            #
-##            # pgWINversion: REL_X_Y.future-future
-##            #
-##            # not "MSYS2testonpgWIN: true" - because no existing "PostgreSQL REL_X_Y for Windows" exists anywhere.
-##            #
-##            # This may not be available if pgSRCversion is 'RC' or 'BETA'.
-##            # pgWINversion: x.y-z
-##            # This may not be available if pgSRCversion is 'RC' or 'BETA'.
-##            # MSYS2testonpgWIN: true
-##            # pgWINversion: 18.?-?
-##            MSYS2testonpgWIN: false
-##
-##
-##          # R latest and PostgreSQL latest (buildpgFromSRCmethod meson)
-##          - matid: 6
-##            os: windows-latest
-##            GithubActionsIgnoreFail: false
-##            compilerEnv: UCRT64
-##            shellEnv: msys2 {0}
-##            compilerExe: gcc
-##            Platform: x64
-##            Configuration: Release
-##            #
-##            rversion: 4.5.0
-##            R_HOME: 'D:\RINSTALL'
-##            R_ARCH: /x64
-##            #
-##            pgSRCversion: REL_18_STABLE
-##            PG_SOURCE: 'D:\PGSOURCE'
-##            buildpgFromSRC: true
-##            buildpgFromSRCmethod: meson
-##            PG_HOME: 'D:\PGINSTALL'
-##            #
-##            # pgWINversion: 18.?-?
-##            MSYS2testonpgWIN: false
-##
-##
-##          # R latest and PostgreSQL latest (buildpgANDplrInSRCcontrib true)
-##          - matid: 7
-##            os: windows-latest
-##            GithubActionsIgnoreFail: false
-##            compilerEnv: UCRT64
-##            shellEnv: msys2 {0}
-##            compilerExe: gcc
-##            Platform: x64
-##            Configuration: Release
-##            #
-##            rversion: 4.5.0
-##            R_HOME: 'D:\RINSTALL'
-##            R_ARCH: /x64
-##            #
-##            pgSRCversion: REL_18_STABLE
-##            PG_SOURCE: 'D:\PGSOURCE'
-##            buildpgANDplrInSRCcontrib: true
-##            PG_HOME: 'D:\PGINSTALL'
-##            #
-##            # pgWINversion: 18.?-?
-##            MSYS2testonpgWIN: false
-##
-##          # R bleeding edge and PostgreSQL latest (buildpgFromSRCmethod meson)
-##          - matid: 8
-##            os: windows-latest
-##            GithubActionsIgnoreFail: true
-##            compilerEnv: UCRT64
-##            shellEnv: msys2 {0}
-##            compilerExe: gcc
-##            Platform: x64
-##            Configuration: Debug
-##            #
-##            rversion:  devel
-##            R_HOME: 'D:\RINSTALL'
-##            R_ARCH: /x64
-##            #
-##            pgSRCversion: REL_17_STABLE
-##            PG_SOURCE: 'D:\PGSOURCE'
-##            buildpgFromSRC: true
-##            buildpgFromSRCmethod: meson
-##            PG_HOME: 'D:\PGINSTALL'
-##            #
-##            # pgWINversion: REL_X_Y.future-future
-##            #
-##            # not "MSYS2testonpgWIN: true" - because no existing "PostgreSQL REL_X_Y for Windows" exists anywhere.
-##            #
-##            # This may not be available if pgSRCversion is 'RC' or 'BETA'.
-##            # pgWINversion: x.y-z
-##            # This may not be available if pgSRCversion is 'RC' or 'BETA'.
-##            # MSYS2testonpgWIN: true
-##            pgWINversion: 17.5-1
-##            MSYS2testonpgWIN: true
-##
-##
-##          # R latest and PostgreSQL latest (buildpgFromSRCmethod meson)
-##          - matid: 9
-##            os: windows-latest
-##            GithubActionsIgnoreFail: false
-##            compilerEnv: UCRT64
-##            shellEnv: msys2 {0}
-##            compilerExe: gcc
-##            Platform: x64
-##            Configuration: Release
-##            #
-##            rversion: 4.5.0
-##            R_HOME: 'D:\RINSTALL'
-##            R_ARCH: /x64
-##            #
-##            pgSRCversion: REL_17_STABLE
-##            PG_SOURCE: 'D:\PGSOURCE'
-##            buildpgFromSRC: true
-##            buildpgFromSRCmethod: meson
-##            PG_HOME: 'D:\PGINSTALL'
-##            #
-##            pgWINversion: 17.5-1
-##            MSYS2testonpgWIN: true
-##
-##
-##          # R latest and PostgreSQL latest (buildpgANDplrInSRCcontrib true)
-##          - matid: 10
-##            os: windows-latest
-##            GithubActionsIgnoreFail: false
-##            compilerEnv: UCRT64
-##            shellEnv: msys2 {0}
-##            compilerExe: gcc
-##            Platform: x64
-##            Configuration: Release
-##            #
-##            rversion: 4.5.0
-##            R_HOME: 'D:\RINSTALL'
-##            R_ARCH: /x64
-##            #
-##            pgSRCversion: REL_17_STABLE
-##            PG_SOURCE: 'D:\PGSOURCE'
-##            buildpgANDplrInSRCcontrib: true
-##            PG_HOME: 'D:\PGINSTALL'
-##            #
-##            pgWINversion: 17.5-1
-##            MSYS2testonpgWIN: true
-##
-##
-##          - matid: 11
-##            os: windows-latest
-##            GithubActionsIgnoreFail: false
-##            compilerEnv: UCRT64
-##            shellEnv: msys2 {0}
-##            compilerExe: gcc
-##            Platform: x64
-##            Configuration: Release
-##            #
-##            rversion: 4.5.0
-##            R_HOME: 'D:\RINSTALL'
-##            R_ARCH: /x64
-##            #
-##            pgSRCversion: REL_16_STABLE
-##            PG_SOURCE: 'D:\PGSOURCE'
-##            buildpgANDplrInSRCcontrib: true
-##            PG_HOME: 'D:\PGINSTALL'
-##            #
-##            pgWINversion: 16.9-1
-##            MSYS2testonpgWIN: true
-##
-##
-##          - matid: 12
-##            os: windows-latest
-##            GithubActionsIgnoreFail: false
-##            compilerEnv: UCRT64
-##            shellEnv: msys2 {0}
-##            compilerExe: gcc
-##            Platform: x64
-##            Configuration: Release
-##            #
-##            rversion: 4.5.0
-##            R_HOME: 'D:\RINSTALL'
-##            R_ARCH: /x64
-##            #
-##            pgSRCversion: REL_15_STABLE
-##            PG_SOURCE: 'D:\PGSOURCE'
-##            buildpgFromSRC: true
-##            buildpgFromSRCmethod: make
-##            PG_HOME: 'D:\PGINSTALL'
-##            #
-##            pgWINversion: 15.13-1
-##            MSYS2testonpgWIN: true
-##
-##
-##          - matid: 13
-##            os: windows-latest
-##            GithubActionsIgnoreFail: false
-##            compilerEnv: UCRT64
-##            shellEnv: msys2 {0}
-##            compilerExe: gcc
-##            Platform: x64
-##            Configuration: Release
-##            #
-##            rversion: 4.5.0
-##            R_HOME: 'D:\RINSTALL'
-##            R_ARCH: /x64
-##            #
-##            pgSRCversion: REL_14_STABLE
-##            PG_SOURCE: 'D:\PGSOURCE'
-##            buildpgFromSRC: true
-##            buildpgFromSRCmethod: make
-##            PG_HOME: 'D:\PGINSTALL'
-##            #
-##            # EnterpriseDB PostgreSQL for Windows
-##            # pgWINversion: 14.x-y
-              # (if MANUAL would be: 14.18)
-##            #
-##            # A HUMAN must manually see the VERSION here. (seen Jul 13 2024 EST)
-##            # Jul 2024 - Pre-installed Github Actions PostgreSQL for Windows version is x64-14
-##            # ServiceName postgresql-x64-14
-##            # Version 14.12
-##            # REAFFIRMED SEP 29 2024
-##            # https://github.com/actions/runner-images/blob/main/images/windows/Windows2022-Readme.md
-##            # https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-software
-##            #
-##            MSYS2testonpgWIN: true
 
     defaults:
       run:
@@ -423,7 +133,7 @@ jobs:
     steps:
 
       - name: Windows Machine Stats systeminfo
-        if: ${{ matrix.os == 'windows-latest' }}
+        if: ${{ matrix.os == 'windows-2025' }}
         shell: cmd
         run: |
           systeminfo
@@ -435,16 +145,16 @@ jobs:
           git config --global advice.detachedHead false
 
       - name: Matrix Variables
-        if: matrix.os == 'windows-latest'
+        if: matrix.os == 'windows-2025'
         shell: powershell
         run: |
           # systeminfo
           echo "${{ matrix.compilerEnv }} on ${{ matrix.os }}"
-          # JUL 2023 - only THIS exists in Github Actions
-          if( Test-Path "C:\Program Files\PostgreSQL\14" ) {
-            "PostgreSQL for Windows x64-14 exists."
+          # AUG 2025 - THIS exists in Github Actions
+          if( Test-Path "C:\Program Files\PostgreSQL\17" ) {
+            "PostgreSQL for Windows x64-17 exists."
           } else {
-            "PostgreSQL for Windows x64-14 does not exist."
+            "PostgreSQL for Windows x64-17 does not exist."
           }
           function Set-EnvVar {param($X)     Add-Content -Path ${env:GITHUB_ENV} -Value "$X"}
           #
@@ -653,7 +363,7 @@ jobs:
           if("${env:pgWINversion}" -eq "notset") {
             if("${env:pgWINServiceNameHostDefault}" -match "(\d+[.]{0,1}\d+$)") {
               # if (1) no entry "pgWINversion: whatever" and yes entry "MSYS2testonpgWIN: true"
-              # then THIS(14) is the default TESTING(14) "MSYS2testonpgWIN PostgreSQL"
+              # then THIS(17) is the default TESTING(17) "MSYS2testonpgWIN PostgreSQL"
               # 9.6
               # 13
               ${env:pgwinmajor} = $matches[1]; $matches = @()
@@ -740,7 +450,7 @@ jobs:
 
 
       - name: Matrix Windows Platform Specific Variables
-        if: ${{ env.os == 'windows-latest' && ( env.compilerClass == 'MSYS2' || env.compilerClass == 'msvc' ) }}
+        if: ${{ env.os == 'windows-2025' && ( env.compilerClass == 'MSYS2' || env.compilerClass == 'msvc' ) }}
         shell: powershell
         run: |
           function Set-EnvVar {param($X)     Add-Content -Path ${env:GITHUB_ENV} -Value "$X"}
@@ -782,7 +492,7 @@ jobs:
           echo "CRAN_R_DOWNLOAD_URL: ${env:CRAN_R_DOWNLOAD_URL}"
 
       - name: Checkout Code of This Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       # running Meson on GitHub Actions will end up using GCC rather than MSVC
       #
@@ -792,7 +502,7 @@ jobs:
       # `x64` for 64-bit x86 machines, `x86` for 32-bit x86 machines.
       # https://github.com/bus1/cabuild/blob/8c91ebf06b7a5f8405cf93c89a6928e4c76967e0/action/msdevshell/action.yml
       - name: Prepare Github Actions, MSVC, and Meson
-        if: ${{ env.os == 'windows-latest' && env.compilerClass == 'msvc' }}
+        if: ${{ env.os == 'windows-2025' && env.compilerClass == 'msvc' }}
         uses: bus1/cabuild/action/msdevshell@v1
         with:
           # msvc ARCHITECTURE
@@ -800,7 +510,7 @@ jobs:
 
       - name: Checkout PostgreSQL Code
         if: ${{ env.pgSRCversion != 'notset' }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: 'postgres/postgres'
 
@@ -827,7 +537,7 @@ jobs:
           path: PGSOURCE
 
       - name: Windows Move PostgreSQL Code
-        if: ${{ env.os == 'windows-latest' && env.pgSRCversion != 'notset' }}
+        if: ${{ env.os == 'windows-2025' && env.pgSRCversion != 'notset' }}
         shell: powershell
         run: |
           Copy-Item -Path PGSOURCE -Destination ${{ env.PG_SOURCE }} -Recurse -Force
@@ -842,7 +552,7 @@ jobs:
       # https://github.com/actions/cache/blob/main/tips-and-workarounds.md#update-a-cache
       #
       - name: Cache R-x.y.z Windows Installer Exe
-        if: ${{ env.os == 'windows-latest' && ( env.compilerClass == 'MSYS2' || env.compilerClass == 'msvc' ) && env.rversion != 'devel' }}
+        if: ${{ env.os == 'windows-2025' && ( env.compilerClass == 'MSYS2' || env.compilerClass == 'msvc' ) && env.rversion != 'devel' }}
         uses: actions/cache@v4
         id: cacheRWindowsInstallerExe
         with:
@@ -853,8 +563,8 @@ jobs:
 
       - name: Cache PostgreSQL for Windows
         if: >-
-          ${{ env.os == 'windows-latest' && ( env.compilerClass == 'MSYS2' || env.compilerClass == 'msvc' ) && env.pgWINversion != 'notset' &&
-          (( env.PGVER2 == '14' && env.Platform == 'x86' ) || ( env.PGVER2 != '14' ))
+          ${{ env.os == 'windows-2025' && ( env.compilerClass == 'MSYS2' || env.compilerClass == 'msvc' ) && env.pgWINversion != 'notset' &&
+          (( env.PGVER2 == '17' && env.Platform == 'x86' ) || ( env.PGVER2 != '17' ))
           }}
         uses: actions/cache@v4
         id: cachePGWindowsInstallerExe
@@ -865,7 +575,7 @@ jobs:
           SEGMENT_DOWNLOAD_TIMEOUT_MINS: 10
 
       - name: Cache GNU diffutils for Test on PostgreSQL for Windows
-        if: ${{ ( env.os == 'windows-latest' && env.compilerClass == 'MSYS2' && env.MSYS2testonpgWIN == 'true' ) || ( env.os == 'windows-latest' && env.compilerClass == 'msvc' ) }}
+        if: ${{ ( env.os == 'windows-2025' && env.compilerClass == 'MSYS2' && env.MSYS2testonpgWIN == 'true' ) || ( env.os == 'windows-2025' && env.compilerClass == 'msvc' ) }}
         uses: actions/cache@v4
         id: cacheDiffutilsZip
         with:
@@ -875,7 +585,7 @@ jobs:
           SEGMENT_DOWNLOAD_TIMEOUT_MINS: 1
 
       - name: Cache pkgconfiglite for Compile using msvc and meson
-        if: ${{ env.os == 'windows-latest' && env.compilerClass == 'msvc' }}
+        if: ${{ env.os == 'windows-2025' && env.compilerClass == 'msvc' }}
         uses: actions/cache@v4
         id: cachePkgConfigLiteZip
         with:
@@ -885,7 +595,7 @@ jobs:
           SEGMENT_DOWNLOAD_TIMEOUT_MINS: 1
 
       - name: Cache winflexbison for Compile using msvc
-        if: ${{ env.os == 'windows-latest' && env.compilerClass == 'msvc' }}
+        if: ${{ env.os == 'windows-2025' && env.compilerClass == 'msvc' }}
         uses: actions/cache@v4
         id: cacheWinFlexBisonZip
         with:
@@ -895,7 +605,7 @@ jobs:
           SEGMENT_DOWNLOAD_TIMEOUT_MINS: 1
 
       - name: Cache meson for Compile using msvc and meson
-        if: ${{ env.os == 'windows-latest' && env.compilerClass == 'msvc' }}
+        if: ${{ env.os == 'windows-2025' && env.compilerClass == 'msvc' }}
         uses: actions/cache@v4
         id: cacheMesonMsi
         with:
@@ -905,7 +615,7 @@ jobs:
           SEGMENT_DOWNLOAD_TIMEOUT_MINS: 1
 
       - name: Cache StrawberryPerl
-        if: ${{ env.os == 'windows-latest' && env.compilerClass == 'MSYS2' && env.compilerEnv == 'MINGW32' }}
+        if: ${{ env.os == 'windows-2025' && env.compilerClass == 'MSYS2' && env.compilerEnv == 'MINGW32' }}
         uses: actions/cache@v4
         id: cacheStrawberryPerlMsi
         with:
@@ -925,7 +635,7 @@ jobs:
       # five seconds
       - name: Download R for Windows R-x.y.z R-rmajor.rminor.rpatch
         if: >-
-          ${{ env.os == 'windows-latest' && ( env.compilerClass == 'MSYS2' || env.compilerClass == 'msvc' ) &&
+          ${{ env.os == 'windows-2025' && ( env.compilerClass == 'MSYS2' || env.compilerClass == 'msvc' ) &&
           steps.cacheRWindowsInstallerExe.outputs.cache-hit != 'true'
           }}
         uses: suisei-cn/actions-download-file@v1.6.0
@@ -935,8 +645,8 @@ jobs:
 
       - name: Download PostgreSQL for Windows
         if: >-
-          ${{ env.os == 'windows-latest' && ( env.compilerClass == 'MSYS2' || env.compilerClass == 'msvc' ) && env.pgWINversion != 'notset' &&
-          (( env.PGVER2 == '14' && env.Platform == 'x86' ) || ( env.PGVER2 != '14' )) &&
+          ${{ env.os == 'windows-2025' && ( env.compilerClass == 'MSYS2' || env.compilerClass == 'msvc' ) && env.pgWINversion != 'notset' &&
+          (( env.PGVER2 == '17' && env.Platform == 'x86' ) || ( env.PGVER2 != '17' )) &&
           steps.cachePGWindowsInstallerExe.outputs.cache-hit != 'true'
           }}
         uses: suisei-cn/actions-download-file@v1.6.0
@@ -951,7 +661,7 @@ jobs:
 #         args: install diffutils
 
       - name: Download GNU diffutils for Test on PostgreSQL for Windows
-        if: ${{ ( ( env.os == 'windows-latest' && env.compilerClass == 'MSYS2' && env.MSYS2testonpgWIN == 'true' ) || ( env.os == 'windows-latest' && env.compilerClass == 'msvc' ) ) &&
+        if: ${{ ( ( env.os == 'windows-2025' && env.compilerClass == 'MSYS2' && env.MSYS2testonpgWIN == 'true' ) || ( env.os == 'windows-2025' && env.compilerClass == 'msvc' ) ) &&
           steps.cacheDiffutilsZip.outputs.cache-hit != 'true'
           }}
         uses: suisei-cn/actions-download-file@v1.6.0
@@ -964,7 +674,7 @@ jobs:
 
       - name: Download pkgconfiglite for Compile using msvc and meson
         if: >-
-          ${{ env.os == 'windows-latest' && env.compilerClass == 'msvc' &&
+          ${{ env.os == 'windows-2025' && env.compilerClass == 'msvc' &&
           steps.cachePkgConfigLiteZip.outputs.cache-hit != 'true'
           }}
         uses: suisei-cn/actions-download-file@v1.6.0
@@ -977,7 +687,7 @@ jobs:
 
       - name: Download winflexbison for Compile using msvc
         if: >-
-          ${{ env.os == 'windows-latest' && env.compilerClass == 'msvc' &&
+          ${{ env.os == 'windows-2025' && env.compilerClass == 'msvc' &&
           steps.cacheWinFlexBisonZip.outputs.cache-hit != 'true'
           }}
         uses: suisei-cn/actions-download-file@v1.6.0
@@ -990,7 +700,7 @@ jobs:
 
       - name: Download meson for Compile using msvc and meson
         if: >-
-          ${{ env.os == 'windows-latest' && env.compilerClass == 'msvc' &&
+          ${{ env.os == 'windows-2025' && env.compilerClass == 'msvc' &&
           steps.cacheMesonMsi.outputs.cache-hit != 'true'
           }}
         uses: suisei-cn/actions-download-file@v1.6.0
@@ -1008,7 +718,7 @@ jobs:
 
       - name: Download StrawberryPerl
         if: >-
-          ${{ env.os == 'windows-latest' && env.compilerClass == 'MSYS2' && env.compilerEnv == 'MINGW32' &&
+          ${{ env.os == 'windows-2025' && env.compilerClass == 'MSYS2' && env.compilerEnv == 'MINGW32' &&
           steps.cacheStrawberryPerlMsi.outputs.cache-hit != 'true'
           }}
         uses: suisei-cn/actions-download-file@v1.6.0
@@ -1022,7 +732,7 @@ jobs:
           url: https://github.com/StrawberryPerl/Perl-Dist-Strawberry/releases/download/SP_53822_64bit/strawberry-perl-5.38.2.2-64bit.msi
 
       - name: Install R for Windows R-x.y.z R-rmajor.rminor.rpatch
-        if: ${{ env.os == 'windows-latest' && ( env.compilerClass == 'MSYS2' || env.compilerClass == 'msvc' ) }}
+        if: ${{ env.os == 'windows-2025' && ( env.compilerClass == 'MSYS2' || env.compilerClass == 'msvc' ) }}
         env:
           R_HOME: ${{ env.R_HOME }}
           R_ARCHplat: ${{ env.R_ARCHplat }}
@@ -1037,40 +747,39 @@ jobs:
           "${{ env.rversionlong }}.exe" /VERYSILENT /COMPONENTS=main,%R_ARCHplat% /DIR=%R_HOME% /NOICONS /TASKS=
           dir "%R_HOME%"
 
-      # Github Actions provided PostgreSQL x64-14 (as of Jul 2024)
+      # Github Actions provided PostgreSQL x64-17 (as of Aug 2025)
       #
-      # # Jul 2024
-      # # The PL/R extension was built using PostreSQL 15
-      # ServiceName postgresql-x64-14
-      # Version 14.12
+      # # Aug 2025
+      # ServiceName postgresql-x64-17
+      # Version 17.5
       # ServiceStatus Stopped
       # ServiceStartType Disabled
-      # EnvironmentVariables PGBIN=C:\Program Files\PostgreSQL\14\bin
-      # PGDATA=C:\Program Files\PostgreSQL\14\data
-      # PGROOT=C:\Program Files\PostgreSQL\14
-      # Path C:\Program Files\PostgreSQL\14
+      # EnvironmentVariables PGBIN=C:\Program Files\PostgreSQL\17\bin
+      # PGDATA=C:\Program Files\PostgreSQL\17\data
+      # PGROOT=C:\Program Files\PostgreSQL\17
+      # Path C:\Program Files\PostgreSQL\17
       # UserName postgres
       # Password root
       # #
-      # https://github.com/actions/runner-images/blob/main/images/windows/Windows2022-Readme.md
+      # https://github.com/actions/runner-images/blob/main/images/windows/Windows2025-Readme.md
       # https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-software
       #
-      - name: From Disabled, Enable PostgreSQL x64-14 for Windows and Start and Stop
+      - name: From Disabled, Enable PostgreSQL x64-17 for Windows and Start and Stop
         if: >-
-          ${{ env.os == 'windows-latest' && ( env.compilerClass == 'MSYS2' && env.MSYS2testonpgWIN == 'true' || env.compilerClass == 'msvc' ) &&
-          env.PGVER2 == '14' && env.Platform == 'x64'
+          ${{ env.os == 'windows-2025' && ( env.compilerClass == 'MSYS2' && env.MSYS2testonpgWIN == 'true' || env.compilerClass == 'msvc' ) &&
+          env.PGVER2 == '17' && env.Platform == 'x64'
           }}
         shell: cmd
         run: |
           echo on
-          sc config "postgresql-x64-14" start= auto
-          net start  postgresql-x64-14
-          net stop   postgresql-x64-14
+          sc config "postgresql-x64-17" start= auto
+          net start  postgresql-x64-17
+          net stop   postgresql-x64-17
 
       - name: Install PostgreSQL for Windows and Stop PostgreSQL
         if: >-
-          ${{ env.os == 'windows-latest' && ( env.compilerClass == 'MSYS2' || env.compilerClass == 'msvc' ) && env.pgWINversion != 'notset' &&
-          (( env.PGVER2 == '14' && env.Platform == 'x86' ) || ( env.PGVER2 != '14' ))
+          ${{ env.os == 'windows-2025' && ( env.compilerClass == 'MSYS2' || env.compilerClass == 'msvc' ) && env.pgWINversion != 'notset' &&
+          (( env.PGVER2 == '17' && env.Platform == 'x86' ) || ( env.PGVER2 != '17' ))
           }}
         env:
           PGVER2: ${{ env.PGVER2 }}
@@ -1110,7 +819,7 @@ jobs:
       #   NOTE - meson - fails with msiexec.exe Exit code was '3010' (see OTHER step)
       #   NOTE - 7z is provided by Github Actions
       - name: Choco Install support software about PL/R compiling using msvc for Windows
-        if: ${{ env.os == 'windows-latest' && env.compilerClass == 'msvc' }}
+        if: ${{ env.os == 'windows-2025' && env.compilerClass == 'msvc' }}
         # Keep v2.  v2.2.0 may have connection to Sourceforge problems
         uses: crazy-max/ghaction-chocolatey@v3
         with:
@@ -1121,7 +830,7 @@ jobs:
       # Choco Install GNU diffutils
       # BUT the "crazy-max/ghaction-chocolatey@v2" "install diffutils" file download often times-out
       - name: Extract Diffuntils and add Diffuntils bin directory to the PATH for Test on PostgreSQL for Windows
-        if: ${{ ( env.os == 'windows-latest' && env.compilerClass == 'MSYS2' && env.MSYS2testonpgWIN == 'true' ) || ( env.os == 'windows-latest' && env.compilerClass == 'msvc' ) }}
+        if: ${{ ( env.os == 'windows-2025' && env.compilerClass == 'MSYS2' && env.MSYS2testonpgWIN == 'true' ) || ( env.os == 'windows-2025' && env.compilerClass == 'msvc' ) }}
         shell: cmd
         run: |
           rem MKDIR creates any intermediate directories in the path, if needed.
@@ -1136,7 +845,7 @@ jobs:
       # Choco Install pkgconfiglite
       # BUT the "crazy-max/ghaction-chocolatey@v2" "install pkgconfiglite" file download often times-out
       - name: Extract pkgconfiglite and add pkgconfiglite bin directory to the PATH for Compile using msvc and meson
-        if: ${{ env.os == 'windows-latest' && env.compilerClass == 'msvc' }}
+        if: ${{ env.os == 'windows-2025' && env.compilerClass == 'msvc' }}
         shell: cmd
         run: |
           rem MKDIR creates any intermediate directories in the path, if needed.
@@ -1151,7 +860,7 @@ jobs:
       # Choco Install winflexbison
       # BUT the "crazy-max/ghaction-chocolatey@v2" "install pkgconfiglite" file download often times-out
       - name: Extract winflexbison and add the winflexbison directory to the PATH for Compile using msvc
-        if: ${{ env.os == 'windows-latest' && env.compilerClass == 'msvc' }}
+        if: ${{ env.os == 'windows-2025' && env.compilerClass == 'msvc' }}
         shell: cmd
         run: |
           rem MKDIR creates any intermediate directories in the path, if needed.
@@ -1166,7 +875,7 @@ jobs:
       # Choco Install meson
       # BUT the "crazy-max/ghaction-chocolatey@v3" "install meson" msiexec.exe Exit code was '3010'.
       - name: Install meson and add meson directory to the PATH for Compile using msvc and meson
-        if: ${{ env.os == 'windows-latest' && env.compilerClass == 'msvc' }}
+        if: ${{ env.os == 'windows-2025' && env.compilerClass == 'msvc' }}
         shell: cmd
         run: |
           msiexec.exe /i meson-1.4.1-64.msi /qn /norestart /l*v meson.1.4.1.MsiInstall.log
@@ -1174,7 +883,7 @@ jobs:
           type meson.1.4.1.MsiInstall.log
 
       - name: Install Strawberry Perl
-        if: ${{ env.os == 'windows-latest' && env.compilerClass == 'MSYS2' && env.compilerEnv == 'MINGW32' }}
+        if: ${{ env.os == 'windows-2025' && env.compilerClass == 'MSYS2' && env.compilerEnv == 'MINGW32' }}
         shell: cmd
         run: |
           msiexec.exe /i strawberry-perl-5.38.2.2-64bit.msi /qn /norestart /l*v strawberry-perl-5.38.2.2-64bit.msiInstall.log
@@ -1184,7 +893,7 @@ jobs:
       # 34 seconds with zero packages
       # 2 minutes and seven(7) seconds with everything
       - name: Install Windows mingw Software
-        if: ${{ env.os == 'windows-latest' && env.compilerClass == 'MSYS2' && env.compilerEnv != 'MINGW32' }}
+        if: ${{ env.os == 'windows-2025' && env.compilerClass == 'MSYS2' && env.compilerEnv != 'MINGW32' }}
         uses: msys2/setup-msys2@v2
         with:
           # By default, the installation is not updated; hence package versions are those of the installation tarball.
@@ -1227,7 +936,7 @@ jobs:
       # 34 seconds with zero packages
       # 2 minutes and seven(7) seconds with everything
       - name: Install Windows mingw Software - same as above - but omit software - perl winpty
-        if: ${{ env.os == 'windows-latest' && env.compilerClass == 'MSYS2' && env.compilerEnv == 'MINGW32' }}
+        if: ${{ env.os == 'windows-2025' && env.compilerClass == 'MSYS2' && env.compilerEnv == 'MINGW32' }}
         uses: msys2/setup-msys2@v2
         with:
           # By default, the installation is not updated; hence package versions are those of the installation tarball.
@@ -1267,7 +976,7 @@ jobs:
 
 
       - name: Install Windows mingw Software Repository PostgreSQL
-        if: ${{ env.os == 'windows-latest' && env.compilerClass == 'MSYS2' && env.buildpgFromSRC != 'true' }}
+        if: ${{ env.os == 'windows-2025' && env.compilerClass == 'MSYS2' && env.buildpgFromSRC != 'true' }}
         env:
           # Msys OS variable
           msystem: ${{ env.compilerEnv }}
@@ -1277,14 +986,16 @@ jobs:
           pacman -S --needed --noconfirm ${{ env.MINGW_PACKAGE_PREFIX }}-postgresql
 
       - name: Set up Cygwin
-        if: ${{ env.os == 'windows-latest' && env.compilerClass == 'cygwin' }}
-        uses: cygwin/cygwin-install-action@v5
+        if: ${{ env.os == 'windows-2025' && env.compilerClass == 'cygwin' }}
+        uses: cygwin/cygwin-install-action@v6
         with:
           # x86 or x86_64
           #         GitHub offers ternary operator like behaviour that you can use in expressions
           platform: ${{ env.Platform == 'x64' && 'x86_64' || 'x86' }}
+          install-dir: 'C:\cygwin'
           # REQUIRED def true - otherwise the default install MING64 "bash" will be found
           # add-to-path: true
+          work-vol: 'C:'
           packages: >-
              cygrunsrv pkg-config  meson  gendef
              gcc-core  make  tar  gzip  libreadline7  zlib  icu-devel  bison  perl
@@ -1297,7 +1008,7 @@ jobs:
 
       # If the PostgreSQL version is 16 or greater, I can compile PostgreSQL using meson.
       - name: Compile PG using pgSRCversion and PG_SOURCE and Install to here PG_HOME
-        if: ${{ env.os == 'windows-latest' && ( env.compilerClass == 'MSYS2' || env.compilerClass == 'cygwin' ) && env.buildpgFromSRC == 'true' }}
+        if: ${{ env.os == 'windows-2025' && ( env.compilerClass == 'MSYS2' || env.compilerClass == 'cygwin' ) && env.buildpgFromSRC == 'true' }}
         env:
           # Cygwin OS variables
           SHELLOPTS: igncr
@@ -1454,7 +1165,7 @@ jobs:
           fi
 
       - name: Windows Prep PG Artifact
-        if: ${{ env.os == 'windows-latest' && env.compilerClass == 'MSYS2' && env.buildpgFromSRC == 'true' }}
+        if: ${{ env.os == 'windows-2025' && env.compilerClass == 'MSYS2' && env.buildpgFromSRC == 'true' }}
         env:
           PGVER2: ${{ env.PGVER2 }}
           Platform: ${{ env.Platform }}
@@ -1462,8 +1173,8 @@ jobs:
         run: |
           echo on
           dir
-          if exist pg-artifact.7z copy pg-artifact.7z pg-matid-${{ matrix.matid }}-${{ env.os }}-${{ env.compilerEnv }}-${{ env.Platform }}-PG${{ env.pgversion }}-${{ env.Configuration }}-R${{ env.rversion }}-PGSRC${{ env.buildpgFromSRC }}-PGSRCMETH${{ env.buildpgFromSRCmethod }}-SRCCTB${{ env.buildpgANDplrInSRCcontrib }}.7z
-          if exist pg-artifact.7z dir                 pg-matid-${{ matrix.matid }}-${{ env.os }}-${{ env.compilerEnv }}-${{ env.Platform }}-PG${{ env.pgversion }}-${{ env.Configuration }}-R${{ env.rversion }}-PGSRC${{ env.buildpgFromSRC }}-PGSRCMETH${{ env.buildpgFromSRCmethod }}-SRCCTB${{ env.buildpgANDplrInSRCcontrib }}.7z
+          if exist pg-artifact.7z copy pg-artifact.7z pg-matid-${{ matrix.matid }}-${{ env.compilerEnv }}-${{ env.Platform }}-PG${{ env.pgversion }}-${{ env.Configuration }}-R${{ env.rversion }}-PGSRC${{ env.buildpgFromSRC }}-PGSRCMETH${{ env.buildpgFromSRCmethod }}-SRCCTB${{ env.buildpgANDplrInSRCcontrib }}.7z
+          if exist pg-artifact.7z dir                 pg-matid-${{ matrix.matid }}-${{ env.compilerEnv }}-${{ env.Platform }}-PG${{ env.pgversion }}-${{ env.Configuration }}-R${{ env.rversion }}-PGSRC${{ env.buildpgFromSRC }}-PGSRCMETH${{ env.buildpgFromSRCmethod }}-SRCCTB${{ env.buildpgANDplrInSRCcontrib }}.7z
 
 ##      # @v4 - Due to how Artifacts are created in this new version,
 ##      # it is no longer possible to upload to the same named Artifact multiple times.
@@ -1471,15 +1182,15 @@ jobs:
 ##      # github.com/actions/upload-artifact
 ##      #
 ##      - name: Upload artifact PG for export for LOCAL testing
-##        if: ${{ env.os == 'windows-latest' &&  env.compilerClass == 'MSYS2' && env.buildpgFromSRC == 'true' }}
+##        if: ${{ env.os == 'windows-2025' &&  env.compilerClass == 'MSYS2' && env.buildpgFromSRC == 'true' }}
 ##        uses: actions/upload-artifact@v4
 ##        with:
-##          name: pg-matid-${{ matrix.matid }}-${{ env.os }}-${{ env.compilerEnv }}-${{ env.Platform }}-PG${{ env.pgversion }}-${{ env.Configuration }}-R${{ env.rversion }}-PGSRC${{ env.buildpgFromSRC }}-PGSRCMETH${{ env.buildpgFromSRCmethod }}-SRCCTB${{ env.buildpgANDplrInSRCcontrib }}
+##          name: pg-matid-${{ matrix.matid }}-${{ env.compilerEnv }}-${{ env.Platform }}-PG${{ env.pgversion }}-${{ env.Configuration }}-R${{ env.rversion }}-PGSRC${{ env.buildpgFromSRC }}-PGSRCMETH${{ env.buildpgFromSRCmethod }}-SRCCTB${{ env.buildpgANDplrInSRCcontrib }}
 ##          path: |
-##            pg-matid-${{ matrix.matid }}-${{ env.os }}-${{ env.compilerEnv }}-${{ env.Platform }}-PG${{ env.pgversion }}-${{ env.Configuration }}-R${{ env.rversion }}-PGSRC${{ env.buildpgFromSRC }}-PGSRCMETH${{ env.buildpgFromSRCmethod }}-SRCCTB${{ env.buildpgANDplrInSRCcontrib }}.7z
+##            pg-matid-${{ matrix.matid }}-${{ env.compilerEnv }}-${{ env.Platform }}-PG${{ env.pgversion }}-${{ env.Configuration }}-R${{ env.rversion }}-PGSRC${{ env.buildpgFromSRC }}-PGSRCMETH${{ env.buildpgFromSRCmethod }}-SRCCTB${{ env.buildpgANDplrInSRCcontrib }}.7z
 
       - name: Windows non-msvc Meson PG and Meson PL/R Setup Compile and Non-Meson Manual Test
-        if: ${{ env.os == 'windows-latest' && ( env.compilerClass == 'MSYS2' || env.compilerClass == 'cygwin' ) && env.buildpgANDplrInSRCcontrib == 'true' }}
+        if: ${{ env.os == 'windows-2025' && ( env.compilerClass == 'MSYS2' || env.compilerClass == 'cygwin' ) && env.buildpgANDplrInSRCcontrib == 'true' }}
         env:
           # Cygwin shell variables
           SHELLOPTS: igncr
@@ -1982,7 +1693,7 @@ jobs:
 
           # meson has no "test" pre-req system.  So this "ordered" implentation is a kind of "hack".
           # sometimes the "plr" regression test fails if an "easier" regression test did not come before it.
-          # true - cube failed its regression test and blocked plr - R devel PGsrc REL_17_BETA2 PGbin UCRT64 x64 windows-latest Debug
+          # true - cube failed its regression test and blocked plr - R devel PGsrc REL_17_BETA2 PGbin UCRT64 x64 windows-2025 Debug
 
           # classic of 2023 and pg16
           # meson test -C build --num-processes 1 -v --suite setup --suite cube
@@ -2064,7 +1775,7 @@ jobs:
           fi
 
       - name: Windows non-msvc Meson PL/R Setup Compile and Non-Meson Manual Test
-        if: ${{ env.os == 'windows-latest' && ( env.compilerClass == 'MSYS2' || env.compilerClass == 'cygwin' ) && env.buildpgANDplrInSRCcontrib != 'true' }}
+        if: ${{ env.os == 'windows-2025' && ( env.compilerClass == 'MSYS2' || env.compilerClass == 'cygwin' ) && env.buildpgANDplrInSRCcontrib != 'true' }}
         env:
           # Cygwin shell variables
           SHELLOPTS: igncr
@@ -2646,7 +2357,7 @@ jobs:
           fi
 
       - name: Windows     msvc Meson PL/R Setup Compile and Non-Meson Manual Test
-        if: ${{ env.os == 'windows-latest' && env.compilerClass == 'msvc' }}
+        if: ${{ env.os == 'windows-2025' && env.compilerClass == 'msvc' }}
         env:
           R_HOME: ${{ env.R_HOME }}
           Platform: ${{ env.Platform }}
@@ -2699,7 +2410,7 @@ jobs:
 ##        if: ${{ always() }}
 ##        uses: actions/upload-artifact@v4
 ##        with:
-##          name: plr-matid-${{ matrix.matid }}-${{ env.HEAD8_GITHUB_SHA }}-${{ env.os }}-${{ env.compilerEnv }}-${{ env.Platform }}-R${{ env.rversion }}-PG${{ env.pgversion }}-${{ env.Configuration }}
+##          name: plr-matid-${{ matrix.matid }}-${{ env.HEAD8_GITHUB_SHA }}-${{ env.compilerEnv }}-${{ env.Platform }}-R${{ env.rversion }}-PG${{ env.pgversion }}-${{ env.Configuration }}
 ##          # default
 ##          if-no-files-found: warn
 ##          path: |
@@ -2707,7 +2418,7 @@ jobs:
 ##            tmp\PLR_LICENSE
 
       - name: Set R_HOME and PG PATH, Start PG(read OS variables), Test on PostgreSQL for Windows
-        if: ${{ env.os == 'windows-latest' && env.compilerClass == 'MSYS2' && env.MSYS2testonpgWIN == 'true' }}
+        if: ${{ env.os == 'windows-2025' && env.compilerClass == 'MSYS2' && env.MSYS2testonpgWIN == 'true' }}
         env:
           R_HOME: ${{ env.R_HOME }}
           R_ARCH: ${{ env.R_ARCH }}
@@ -2768,7 +2479,7 @@ jobs:
           if "%ERRORLEVEL%"=="1" exit 1
 
       - name: Stop PostgreSQL for Windows
-        if: ${{ env.os == 'windows-latest' && env.compilerClass == 'MSYS2' && env.MSYS2testonpgWIN == 'true' }}
+        if: ${{ env.os == 'windows-2025' && env.compilerClass == 'MSYS2' && env.MSYS2testonpgWIN == 'true' }}
         env:
           PGVER2: ${{ env.PGVER2 }}
           Platform: ${{ env.Platform }}
@@ -2783,7 +2494,7 @@ jobs:
           if "%Platform%"=="notset" (echo Platform is not set, therefore no net stop happens.)
 
       - name: Windows Prep PL/R Artifact for Release
-        if: ${{ env.os == 'windows-latest' && ( env.compilerClass == 'MSYS2' || env.compilerClass == 'cygwin' || env.compilerClass == 'msvc' ) }}
+        if: ${{ env.os == 'windows-2025' && ( env.compilerClass == 'MSYS2' || env.compilerClass == 'cygwin' || env.compilerClass == 'msvc' ) }}
         env:
           PGVER2: ${{ env.PGVER2 }}
           Platform: ${{ env.Platform }}
@@ -2791,8 +2502,8 @@ jobs:
         run: |
           echo on
           dir
-          if exist plr-artifact.zip copy plr-artifact.zip plr-matid-${{ matrix.matid }}-${{ env.HEAD8_GITHUB_SHA }}-${{ env.os }}-${{ env.compilerEnv }}-${{ env.Platform }}-R${{ env.rversion }}-PG${{ env.pgversion }}-${{ env.Configuration }}.zip
-          if exist plr-artifact.zip dir                   plr-matid-${{ matrix.matid }}-${{ env.HEAD8_GITHUB_SHA }}-${{ env.os }}-${{ env.compilerEnv }}-${{ env.Platform }}-R${{ env.rversion }}-PG${{ env.pgversion }}-${{ env.Configuration }}.zip
+          if exist plr-artifact.zip copy plr-artifact.zip plr-matid-${{ matrix.matid }}-${{ env.HEAD8_GITHUB_SHA }}-${{ env.compilerEnv }}-${{ env.Platform }}-R${{ env.rversion }}-PG${{ env.pgversion }}-${{ env.Configuration }}.zip
+          if exist plr-artifact.zip dir                   plr-matid-${{ matrix.matid }}-${{ env.HEAD8_GITHUB_SHA }}-${{ env.compilerEnv }}-${{ env.Platform }}-R${{ env.rversion }}-PG${{ env.pgversion }}-${{ env.Configuration }}.zip
 
 ##      # Testing is not done here.
 ##      # Pushing this tag assumes that the previous Github Actions workflow run had all 'successes'.
@@ -2805,5 +2516,5 @@ jobs:
 ##          # "artifacts" means "paths" and "files"
 ##          # set of paths representing artifacts to upload to the release
 ##          artifacts: |
-##            plr-matid-${{ matrix.matid }}-${{ env.HEAD8_GITHUB_SHA }}-${{ env.os }}-${{ env.compilerEnv }}-${{ env.Platform }}-R${{ env.rversion }}-PG${{ env.pgversion }}-${{ env.Configuration }}.zip
+##            plr-matid-${{ matrix.matid }}-${{ env.HEAD8_GITHUB_SHA }}-${{ env.compilerEnv }}-${{ env.Platform }}-R${{ env.rversion }}-PG${{ env.pgversion }}-${{ env.Configuration }}.zip
 ##          token: ${{ secrets.ACTIONS_CREATE_RELEASE_REPO_SECRET }}

--- a/.github/workflows/schedule.yml
+++ b/.github/workflows/schedule.yml
@@ -24,7 +24,7 @@ jobs:
         run: echo building master
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: checkout postgres
         run: |
@@ -69,7 +69,7 @@ jobs:
         run: echo building master
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: checkout postgres
         run: |

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -198,7 +198,7 @@ environment:
     rversion: 4.2.3
     compiler: msvc
 
-  - pg: 16.9-1
+  - pg: 16.10-1
     PlatformToolset: v143
     Configuration: Release
     Platform: x64
@@ -206,7 +206,7 @@ environment:
     rversion: 4.2.3
     compiler: msvc
 
-  - pg: 15.13-1
+  - pg: 15.14-1
     PlatformToolset: v143
     Configuration: Release
     Platform: x64
@@ -214,7 +214,7 @@ environment:
     rversion: 4.2.3
     compiler: msvc
 
-  - pg: 14.18-1
+  - pg: 14.19-1
     PlatformToolset: v143
     Configuration: Release
     Platform: x64
@@ -222,7 +222,7 @@ environment:
     rversion: 4.2.3
     compiler: msvc
 
-  - pg: 13.21-1
+  - pg: 13.22-1
     PlatformToolset: v143
     Configuration: Release
     Platform: x64

--- a/install.md
+++ b/install.md
@@ -11,7 +11,7 @@ This presumes you installed PostgreSQL using the PGDG repositories found [here](
 yum install plr-nn
 ```
 
-Where nn is the major version number such as 17 for PostgreSQL version 17.x
+Where nn is the major version number such as 18 for PostgreSQL version 18.x
 
 To set R_HOME for use by PostgreSQL.
 
@@ -73,8 +73,8 @@ You may explicitly include the path of pg_config to `PATH`, such as
 
 ```bash
 cd plr
-PATH=/usr/pgsql-17/bin/:$PATH; USE_PGXS=1 make
-echo "PATH=/usr/pgsql-17/bin/:$PATH; USE_PGXS=1 make install" | sudo sh
+PATH=/usr/pgsql-18/bin/:$PATH; USE_PGXS=1 make
+echo "PATH=/usr/pgsql-18/bin/:$PATH; USE_PGXS=1 make install" | sudo sh
 ```
 If you want to use git to pull the repository, run the following command before the make command:
 
@@ -94,8 +94,8 @@ USE_PGXS=1 make install
 
 In MSYS:
 ```
-export R_HOME=/c/progra~1/R/R-4.5.0 
-export PATH=$PATH:/c/progra~1/PostgreSQL/17/bin
+export R_HOME=/c/progra~1/R/R-4.5.1 
+export PATH=$PATH:/c/progra~1/PostgreSQL/18/bin
 USE_PGXS=1 make
 USE_PGXS=1 make install
 ```
@@ -115,15 +115,15 @@ that has been downloaded (and installed) from
 then, include the environment variable R_ARCH.
 For example R_ARCH=/x64 (or R_ARCH=/i386 as appropriate):
 ```
-export R_HOME=/c/progra~1/R/R-4.5.0
-export PATH=$PATH:/c/progra~1/PostgreSQL/17/bin
+export R_HOME=/c/progra~1/R/R-4.5.1
+export PATH=$PATH:/c/progra~1/PostgreSQL/18/bin
 export R_ARCH=/x64
 USE_PGXS=1 make
 USE_PGXS=1 make install
 ```
 ```
 export R_HOME=/c/progra~1/R/R-4.1.3
-export PATH=$PATH:/c/progra~1/PostgreSQL/17/bin
+export PATH=$PATH:/c/progra~1/PostgreSQL/18/bin
 export R_ARCH=/i386
 USE_PGXS=1 make
 USE_PGXS=1 make install
@@ -159,7 +159,7 @@ changing:
 
 In Windows environment (generally):
 ```
-R_HOME=C:\Progra~1\R\R-4.5.0
+R_HOME=C:\Progra~1\R\R-4.5.1
 Path=%PATH%;%R_HOME%\x64\bin
 ```
 
@@ -219,7 +219,7 @@ and choose [ ] "Save version number in registry".
 At a Command Prompt run (and may have to be an Administrator Command Prompt)
 and using wherever your path to R may be, do:
 ```
-setx R_HOME "C:\Program Files\R\R-4.5.0" /M
+setx R_HOME "C:\Program Files\R\R-4.5.1" /M
 ```
 ### Optionally:
 
@@ -228,7 +228,7 @@ and choose [ ] "Save version number in registry".
 Choose Control Panel -> System -> advanced system settings -> Environment Variables button.
 In the "System variables" area, create the System Variable, called R_HOME.
 Give R_HOME the value of the PATH to the R home,
-for example (without quotes) "C:\Program Files\R\R-4.5.0".
+for example (without quotes) "C:\Program Files\R\R-4.5.1".
 
 If you forgot to set the R_HOME environment variable (by any method),
 then (eventually) you may get this error:
@@ -250,7 +250,7 @@ Control Panel -> System -> Advanced System Settings -> Environment Variables but
 In the "System variables" area, choose the System Variable, called "Path".
 Click on the Edit button.
 Add the R.dll folder to the "Path".
-For example (without quotes), add "C:\Program Files\R\R-4.5.0\bin\x64" or
+For example (without quotes), add "C:\Program Files\R\R-4.5.1\bin\x64" or
 or "C:\Program Files\R\R-4.1.3\bin\i386".
 If you are running R version 2.11 or earlier on Windows, the R.dll folder is different;
 instead of "bin\i386" or "bin\x64", it is "bin".
@@ -270,21 +270,21 @@ Restart the PostgreSQL cluster, do:
 At a Command Prompt run (and you may have to be in an Administrator Command Prompt):
 Use the service name of whatever service your PostgreSQL is running under.
 ```
-net stop postgresql-x64-17
+net stop postgresql-x64-18
 ```
 Alternately, do the following:
 Control Panel -> Administrative Tools -> Services
-Find postgresql-x64-17 (or whatever service your PostgreSQL is running under).
+Find postgresql-x64-18 (or whatever service your PostgreSQL is running under).
 Right click and choose "Stop"
 
 At a Command Prompt run (and you may have to be in an Administrator Command Prompt):
 Use the service name of whatever service your PostgreSQL is running under.
 ```
-net start postgresql-x64-17
+net start postgresql-x64-18
 ```
 Alternately, do the following:
 Control Panel -> Administrative Tools -> Services
-Find postgresql-x64-17 (or whatever service your PostgreSQL is running under).
+Find postgresql-x64-18 (or whatever service your PostgreSQL is running under).
 Right click and choose "Start"
 
 

--- a/userguide.md
+++ b/userguide.md
@@ -77,7 +77,7 @@ This presumes you installed PostgreSQL using the PGDG repositories found [here](
 yum install plr-nn
 ```
 
-Where nn is the major version number such as 17 for PostgreSQL version 17.x
+Where nn is the major version number such as 18 for PostgreSQL version 18.x
 
 To set R_HOME for use by PostgreSQL.
 
@@ -139,8 +139,8 @@ You may explicitly include the path of pg_config to `PATH`, such as
 
 ```bash
 cd plr
-PATH=/usr/pgsql-17/bin/:$PATH; USE_PGXS=1 make
-echo "PATH=/usr/pgsql-17/bin/:$PATH; USE_PGXS=1 make install" | sudo sh
+PATH=/usr/pgsql-18/bin/:$PATH; USE_PGXS=1 make
+echo "PATH=/usr/pgsql-18/bin/:$PATH; USE_PGXS=1 make install" | sudo sh
 ```
 If you want to use git to pull the repository, run the following command before the make command:
 
@@ -160,8 +160,8 @@ USE_PGXS=1 make install
 
 In MSYS:
 ```
-export R_HOME=/c/progra~1/R/R-4.5.0
-export PATH=$PATH:/c/progra~1/PostgreSQL/17/bin
+export R_HOME=/c/progra~1/R/R-4.5.1
+export PATH=$PATH:/c/progra~1/PostgreSQL/18/bin
 USE_PGXS=1 make
 USE_PGXS=1 make install
 ```
@@ -181,15 +181,15 @@ that has been downloaded (and installed) from
 then, include the environment variable R_ARCH.
 For example R_ARCH=/x64 (or R_ARCH=/i386 as appropriate):
 ```
-export R_HOME=/c/progra~1/R/R-4.5.0
-export PATH=$PATH:/c/progra~1/PostgreSQL/17/bin
+export R_HOME=/c/progra~1/R/R-4.5.1
+export PATH=$PATH:/c/progra~1/PostgreSQL/18/bin
 export R_ARCH=/x64
 USE_PGXS=1 make
 USE_PGXS=1 make install
 ```
 ```
 export R_HOME=/c/progra~1/R/R-4.1.3
-export PATH=$PATH:/c/progra~1/PostgreSQL/17/bin
+export PATH=$PATH:/c/progra~1/PostgreSQL/18/bin
 export R_ARCH=/i386
 USE_PGXS=1 make
 USE_PGXS=1 make install
@@ -225,7 +225,7 @@ changing:
 
 In Windows environment (generally):
 ```
-R_HOME=C:\Progra~1\R\R-4.5.0
+R_HOME=C:\Progra~1\R\R-4.5.1
 Path=%PATH%;%R_HOME%\x64\bin
 ```
 
@@ -285,7 +285,7 @@ and choose [ ] "Save version number in registry".
 At a Command Prompt run (and may have to be an Administrator Command Prompt)
 and using wherever your path to R may be, do:
 ```
-setx R_HOME "C:\Program Files\R\R-4.5.0" /M
+setx R_HOME "C:\Program Files\R\R-4.5.1" /M
 ```
 ### Optionally:
 
@@ -294,7 +294,7 @@ and choose [ ] "Save version number in registry".
 Choose Control Panel -> System -> advanced system settings -> Environment Variables button.
 In the "System variables" area, create the System Variable, called R_HOME.
 Give R_HOME the value of the PATH to the R home,
-for example (without quotes) "C:\Program Files\R\R-4.5.0".
+for example (without quotes) "C:\Program Files\R\R-4.5.1".
 
 If you forgot to set the R_HOME environment variable (by any method),
 then (eventually) you may get this error:
@@ -316,7 +316,7 @@ Control Panel -> System -> Advanced System Settings -> Environment Variables but
 In the "System variables" area, choose the System Variable, called "Path".
 Click on the Edit button.
 Add the R.dll folder to the "Path".
-For example (without quotes), add "C:\Program Files\R\R-4.5.0\bin\x64" or
+For example (without quotes), add "C:\Program Files\R\R-4.5.1\bin\x64" or
 or "C:\Program Files\R\R-4.1.3\bin\i386".
 If you are running R version 2.11 or earlier on Windows, the R.dll folder is different;
 instead of "bin\i386" or "bin\x64", it is "bin".
@@ -336,21 +336,21 @@ Restart the PostgreSQL cluster, do:
 At a Command Prompt run (and you may have to be in an Administrator Command Prompt):
 Use the service name of whatever service your PostgreSQL is running under.
 ```
-net stop postgresql-x64-17
+net stop postgresql-x64-18
 ```
 Alternately, do the following:
 Control Panel -> Administrative Tools -> Services
-Find postgresql-x64-17 (or whatever service your PostgreSQL is running under).
+Find postgresql-x64-18 (or whatever service your PostgreSQL is running under).
 Right click and choose "Stop"
 
 At a Command Prompt run (and you may have to be in an Administrator Command Prompt):
 Use the service name of whatever service your PostgreSQL is running under.
 ```
-net start postgresql-x64-17
+net start postgresql-x64-18
 ```
 Alternately, do the following:
 Control Panel -> Administrative Tools -> Services
-Find postgresql-x64-17 (or whatever service your PostgreSQL is running under).
+Find postgresql-x64-18 (or whatever service your PostgreSQL is running under).
 Right click and choose "Start"
 
 


### PR DESCRIPTION
* Upgrade docs to PG18
* Change from Windows Server 2022 to 2025 Windows-latest workflows will use Windows Server 2025 image in GH #12677 https://github.com/actions/runner-images/issues/12677
* Fix random error. Change some work on D to all work on C drive
* Change from the default PG 14 to 17 (windows 2025)
* Upgrade R versions and PG versions
* Shorten Release name length so users can see the file name
* Upgrade specific named Github actions
* Fix mistake. Build PG 16 will now use "meson"
* Lessen the number of build PG 17 matrix entries to just the "meson"