### PR TITLE
PostgreSQL 18 Release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: plr CI
+name: plr CI 
 run-name: plr CI - ${{ github.event.head_commit.message }}
 
 on: 
@@ -50,7 +50,7 @@ jobs:
           USE_PGXS: 1
 
   REL_18_:
-    # SEEN AUG 2025
+    # SEEN SEP 2025
     # Ubuntu 24.04 - ubuntu-latest or ubuntu-24.04
     # https://github.com/actions/runner-images
     # noble (24.04, LTS), plucky (25.04, amd64 only)
@@ -128,7 +128,7 @@ jobs:
     strategy:
       matrix:
         include:
-          # SEEN AUG 2025
+          # SEEN SEP 2025
           # Ubuntu 24.04 - ubuntu-latest or ubuntu-24.04
           # https://github.com/actions/runner-images
           # noble (24.04, LTS), plucky (25.04, amd64 only)
@@ -136,8 +136,9 @@ jobs:
           # https://apt.postgresql.org/pub/repos/apt/dists/
           # ##
           # https://ftp.postgresql.org/pub/repos/apt/dists/noble-pgdg/
-          # Regular expression search - "Package: postgresql-17$"
+          # Regular expression search - "Package: postgresql-18$"
           # https://ftp.postgresql.org/pub/repos/apt/dists/noble-pgdg/main/binary-amd64/Packages
+          - pg: 18
           - pg: 17
           - pg: 16
           - pg: 15

--- a/.github/workflows/buildPLR.yml
+++ b/.github/workflows/buildPLR.yml
@@ -88,9 +88,8 @@ jobs:
           # https://stackoverflow.com/questions/10540228/c-complex-numbers-in-c
           #
 
-          # SEEN MAY 2025 (not yet SWITCHING to windows-2025 - need to modify HARDCODED yaml from 14 to 17)
           # windows-2025 (uses PG 17)
-          # windows-2025 or windows-2025 (uses PG 14)
+          # windows-2022 (uses PG 14)
           # https://github.com/actions/runner-images
 
           # R bleeding edge and PostgreSQL bleeding edge (buildpgFromSRCmethod meson)
@@ -198,8 +197,11 @@ jobs:
             # pgWINversion: x.y-z
             # This may not be available if pgSRCversion is 'RC' or 'BETA'.
             # MSYS2testonpgWIN: true
-            # pgWINversion: 18.?-?
-            MSYS2testonpgWIN: false
+            #
+            #   pgWINversion: 18.?-?
+            #   MSYS2testonpgWIN: false
+            pgWINversion: 18.0-1
+            MSYS2testonpgWIN: true
 
 
           # R latest and PostgreSQL latest (buildpgFromSRCmethod meson)
@@ -222,8 +224,10 @@ jobs:
             buildpgFromSRCmethod: meson
             PG_HOME: 'C:\PGINSTALL'
             #
-            # pgWINversion: 18.?-?
-            MSYS2testonpgWIN: false
+            #   pgWINversion: 18.?-?
+            #   MSYS2testonpgWIN: false
+            pgWINversion: 18.0-1
+            MSYS2testonpgWIN: true
 
 
           # R latest and PostgreSQL latest (buildpgANDplrInSRCcontrib true)
@@ -245,8 +249,10 @@ jobs:
             buildpgANDplrInSRCcontrib: true
             PG_HOME: 'C:\PGINSTALL'
             #
-            # pgWINversion: 18.?-?
-            MSYS2testonpgWIN: false
+            #   pgWINversion: 18.?-?
+            #   MSYS2testonpgWIN: false
+            pgWINversion: 18.0-1
+            MSYS2testonpgWIN: true
 
 
           # R latest and PostgreSQL latest (buildpgFromSRCmethod meson)

--- a/.github/workflows/buildPLRschedule.yml
+++ b/.github/workflows/buildPLRschedule.yml
@@ -100,9 +100,8 @@ jobs:
 ##          # https://stackoverflow.com/questions/10540228/c-complex-numbers-in-c
 ##          #
 ##
-##          # SEEN MAY 2025 (not yet SWITCHING to windows-2025 - need to modify HARDCODED yaml from 14 to 17)
 ##          # windows-2025 (uses PG 17)
-##          # windows-2025 or windows-2025 (uses PG 14)
+##          # windows-2022 (uses PG 14)
 ##          # https://github.com/actions/runner-images
 
           # R bleeding edge and PostgreSQL bleeding edge (buildpgFromSRCmethod meson)

--- a/.github/workflows/schedule.yml
+++ b/.github/workflows/schedule.yml
@@ -12,7 +12,7 @@ on:
       - cron:  '30 1 * * *'
 jobs:
   master:
-    # SEEN MAY 2025
+    # SEEN SEP 2025
     # Ubuntu 24.04	ubuntu-latest
     # https://github.com/actions/runner-images
     # noble (24.04, LTS)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -136,13 +136,14 @@ environment:
     # msvc/msys2? - "pg" 10     - last version "pg" supports x86
     # msvc/msys2? - "r"   4.1.3 - last version "r"  supports x86
 
-  - pg: REL_10_STABLE # static commit - from git
-    PlatformToolset: v143
-    Configuration: Debug
-    Platform: x86
-    APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2022
-    rversion: 4.1.3
-    compiler: msys2
+##  # configure: error: C compiler cannot create executables (seen SEP 29 2025)
+##  - pg: REL_10_STABLE # static commit - from git
+##    PlatformToolset: v143
+##    Configuration: Debug
+##    Platform: x86
+##    APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2022
+##    rversion: 4.1.3
+##    compiler: msys2
 
 #   # msvc - late November 2023
 #   # msvc
@@ -312,7 +313,6 @@ for:
   - if not defined pglinkbinoldurl set pglinkbinoldurl=none
   # not (yet) used in compiler cygwin
   # - if not defined  rlinkbinoldurl set  rlinkbinoldurl=none
-  - if not defined rversion_more set rversion_more=-nodetails
 
   install:
   - echo compiler cygwin install
@@ -590,7 +590,6 @@ for:
   - if not defined pglinkbinoldurl set pglinkbinoldurl=none
   - if not defined  rlinkbinoldurl set  rlinkbinoldurl=none
   - if not defined rversionurl set rversionurl=https://cran.r-project.org/bin/windows/base/old/%rversion%/R-%rversion%-win.exe
-  - if not defined rversion_more set rversion_more=-nodetails
 
   install:
   - echo compiler msys2 install
@@ -870,7 +869,6 @@ for:
   - if not defined pghint      set pghint=none
   - if not defined  rlinkbinoldurl set  rlinkbinoldurl=none
   - if not defined rversionurl set rversionurl=https://cran.r-project.org/bin/windows/base/old/%rversion%/R-%rversion%-win.exe
-  - if not defined rversion_more set rversion_more=-nodetails
 
   install:
   - echo compiler msvc install
@@ -1252,7 +1250,7 @@ for:
   - copy %dll% tmp\lib
   - copy %dll:.dll=.pdb% tmp\symbols
   - dir tmp
-  - set var7z=plr-%APPVEYOR_REPO_COMMIT:~0,8%-pg%pgversion%-R%rversion%%rversion_more%-%Platform%-%Configuration%-%compiler%.7z
+  - set var7z=plr-%APPVEYOR_REPO_COMMIT:~0,8%-pg%pgversion%-R%rversion%-%Platform%-%Configuration%-%compiler%.7z
   - 7z a -t7z -mmt24 -mx7 -r %var7z% .\tmp\* > nul
   - dir "%var7z%"
   - echo appveyor PushArtifact "%var7z%"


### PR DESCRIPTION
PostgreSQL 18 Release

* No PL/R code changes
* Remove "-nodetails" from the Windows Release asset names
* Correct the comment to read "windows-2025 (uses PG 17)"
* Removed from appveyor builds REL_10_STABLE x86 Windows on msys2 (configure: error: C compiler cannot create executable)
* Added PL/R on PostgreSQL 18 on Ubuntu LInux build
* Update testing to include the new EnterpriseDB PostgreSQL Windows version 18.0-1
* Re-push the tag REL8_4_8 to compile PL/R for Windows