### PR TITLE
temporary PG REL_19_ tests on daily Github Actions UCRT64 pg-pre-19 branch  REL_19_STABLE

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -81,32 +81,39 @@ jobs:
           sudo /etc/init.d/postgresql stop
           sudo apt-get remove --purge postgresql\*
           sudo rm -rf /etc/postgresql /var/lib/postgresql
-          export RET=$(git ls-remote --tags https://github.com/postgres/postgres.git | cut -c 52- | grep -c 'REL_19_[0-9]')
+          export PGSRCVERSION=REL_19_
+          export ALLGITTAGS=$(git ls-remote --tags https://github.com/postgres/postgres.git | cut -c 52-)
+          quantity() { echo ${ALLGITTAGS} | tr " " "\n" | grep -c "${PGSRCVERSION}${MARK}[0-9]"; }
+          quality()  { echo ${ALLGITTAGS} | tr " " "\n" | grep -e "${PGSRCVERSION}${MARK}[0-9]" | tail -n 1; }
+          export MARK=""
+          export RET=$(quantity)
           if [ "${RET}" -gt "0" ]
           then
-            export GITTAG=$(git ls-remote --tags https://github.com/postgres/postgres.git | cut -c 52- | grep -e 'REL_19_[0-9]' | tail -n 1)
-            echo -n "Release(s) are found.  Taking the last Release . . . GITTAG: ${GITTAG}"
+            export SPECGITTAG=$(quality)
+            echo -n "Release(s) are found.  Taking the last Release . . . SPECGITTAG: ${SPECGITTAG}"
           else
-            export RET=$(git ls-remote --tags https://github.com/postgres/postgres.git | cut -c 52- | grep -c 'REL_19_RC[0-9]')
+            export MARK="RC"
+            export RET=$(quantity)
             echo "Release(s) are not found.  Trying Release Candidates."
             if [ "${RET}" -gt "0" ]
             then
-              export GITTAG=$(git ls-remote --tags https://github.com/postgres/postgres.git | cut -c 52- | grep -e 'REL_19_RC[0-9]' | tail -n 1)
-              echo -n "Release Candidate(s) are found.  Taking the last Release Candidate . . . GITTAG: ${GITTAG}"
+              export SPECGITTAG=$(quality)
+              echo -n "Release Candidate(s) are found.  Taking the last Release Candidate . . . SPECGITTAG: ${SPECGITTAG}"
             else
-              export RET=$(git ls-remote --tags https://github.com/postgres/postgres.git | cut -c 52- | grep -c 'REL_19_BETA[0-9]')
+              export MARK="BETA"
+              export RET=$(quantity)
               echo "Release Candidate(s) are not found. Trying Betas."
               if [ "${RET}" -gt "0" ]
               then
-                export GITTAG=$(git ls-remote --tags https://github.com/postgres/postgres.git | cut -c 52- | grep -e 'REL_19_BETA[0-9]' | tail -n 1)
-                echo -n "Beta(s) are found. Taking the last Beta . . . GITTAG: ${GITTAG}"
+                export SPECGITTAG=$(quality)
+                echo -n "Beta(s) are found. Taking the last Beta . . . SPECGITTAG: ${SPECGITTAG}"
               else
                 echo "Beta(s) are not found."
               fi
             fi
           fi
-          echo "GITTAG: ${GITTAG}"
-          git clone --branch $GITTAG --depth=1 https://github.com/postgres/postgres.git
+          echo "SPECGITTAG: ${SPECGITTAG}"
+          git clone --branch $SPECGITTAG --depth=1 https://github.com/postgres/postgres.git
           pushd postgres
           ./configure
           make

--- a/.github/workflows/buildPLR.yml
+++ b/.github/workflows/buildPLR.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build_test_install:
-    name: matid ${{ matrix.matid }} R ${{ matrix.rversion }} PGsrc ${{ matrix.pgSRCversion }} PGbin ${{ matrix.pgWINversion }} ${{ matrix.compilerEnv }} ${{ matrix.Platform }}  ${{ matrix.os }} ${{ matrix.Configuration }} R ${{ matrix.rversion }} PGSRC ${{ matrix.buildpgFromSRC }} PGSRCMETH ${{ matrix.buildpgFromSRCmethod }} SRCCTB ${{ matrix.buildpgANDplrInSRCcontrib }}
+    name: matid ${{ matrix.matid }} R ${{ matrix.rversion }} PGsrc ${{ matrix.pgSRCversion }} PGbin ${{ matrix.pgWINversion }} ${{ matrix.compilerEnv }} ${{ matrix.Platform }}  ${{ matrix.os }} ${{ matrix.Configuration }} PGSRC ${{ matrix.buildpgFromSRC }} PGSRCMETH ${{ matrix.buildpgFromSRCmethod }} SRCCTB ${{ matrix.buildpgANDplrInSRCcontrib }}
     runs-on: ${{ matrix.os }}
     # With "continue-on-error" (and with "fail-fast") emulate Appveyor "allow_failures"
     # Prevents a workflow run from failing when a job fails. Set to true to allow a workflow run to pass when this job fails.
@@ -123,7 +123,7 @@ jobs:
             Platform: x64
             Configuration: Debug
             #
-            rversion: 4.6.0
+            rversion: 4.6.1
             R_HOME: 'C:\RINSTALL'
             R_ARCH: /x64
             #
@@ -144,7 +144,7 @@ jobs:
           #  Platform: x64
           #  Configuration: Debug
             #
-          #  rversion: 4.6.0
+          #  rversion: 4.6.1
           #  R_HOME: 'C:\RINSTALL'
           #  R_ARCH: /x64
             #
@@ -170,29 +170,8 @@ jobs:
 
 
           # RSVP for FUTURE USE
-#         # R latest and PostgreSQL release candidate or beta (buildpgANDplrInSRCcontrib true)
-#         - matid: '04'
-#           os: windows-2025-vs2026
-#           GithubActionsIgnoreFail: true
-#           compilerEnv: UCRT64
-#           shellEnv: msys2 {0}
-#           compilerExe: gcc
-#           Platform: x64
-#           Configuration: Debug
-#           #
-#           rversion: 4.6.0
-#           R_HOME: 'C:\RINSTALL'
-#           R_ARCH: /x64
-#           #
-#           pgSRCversion: REL_19_STABLE
-#           PG_SOURCE: 'C:\PGSOURCE'
-#           buildpgFromSRC: true
-#           buildpgFromSRCmethod: meson
-#           PG_HOME: 'C:\PGINSTALL'
-
-
-          # R latest and PostgreSQL release candidate or beta (buildpgANDplrInSRCcontrib true)
-          - matid: '05'
+          # R latest and PostgreSQL release candidate or beta (buildpgFromSRCmethod meson)
+          - matid: '04'
             os: windows-2025-vs2026
             GithubActionsIgnoreFail: true
             compilerEnv: UCRT64
@@ -201,15 +180,36 @@ jobs:
             Platform: x64
             Configuration: Debug
             #
-            rversion: 4.6.0
+            rversion: 4.6.1
             R_HOME: 'C:\RINSTALL'
             R_ARCH: /x64
             #
-            pgSRCversion: REL_19_BETA1
+            pgSRCversion: REL_19_STABLE
             PG_SOURCE: 'C:\PGSOURCE'
             buildpgFromSRC: true
             buildpgFromSRCmethod: meson
             PG_HOME: 'C:\PGINSTALL'
+
+
+#         # R latest and PostgreSQL release candidate or beta (buildpgFromSRCmethod meson)
+#         - matid: '05'
+#           os: windows-2025-vs2026
+#           GithubActionsIgnoreFail: true
+#           compilerEnv: UCRT64
+#           shellEnv: msys2 {0}
+#           compilerExe: gcc
+#           Platform: x64
+#           Configuration: Debug
+#           #
+#           rversion: 4.6.1
+#           R_HOME: 'C:\RINSTALL'
+#           R_ARCH: /x64
+#           #
+#           pgSRCversion: REL_19_BETA1
+#           PG_SOURCE: 'C:\PGSOURCE'
+#           buildpgFromSRC: true
+#           buildpgFromSRCmethod: meson
+#           PG_HOME: 'C:\PGINSTALL'
 
 
           # R bleeding edge and PostgreSQL latest (buildpgFromSRCmethod meson)
@@ -257,7 +257,7 @@ jobs:
             Platform: x64
             Configuration: Release
             #
-            rversion: 4.6.0
+            rversion: 4.6.1
             R_HOME: 'C:\RINSTALL'
             R_ARCH: /x64
             #
@@ -283,7 +283,7 @@ jobs:
           #  Platform: x64
           #  Configuration: Release
             #
-          #  rversion: 4.6.0
+          #  rversion: 4.6.1
           #  R_HOME: 'C:\RINSTALL'
           #  R_ARCH: /x64
             #
@@ -308,7 +308,7 @@ jobs:
             Platform: x64
             Configuration: Release
             #
-            rversion: 4.6.0
+            rversion: 4.6.1
             R_HOME: 'C:\RINSTALL'
             R_ARCH: /x64
             #
@@ -346,7 +346,7 @@ jobs:
             Platform: x64
             Configuration: Release
             #
-            rversion: 4.6.0
+            rversion: 4.6.1
             R_HOME: 'C:\RINSTALL'
             R_ARCH: /x64
             #
@@ -372,7 +372,7 @@ jobs:
             Platform: x64
             Configuration: Release
             #
-            rversion: 4.6.0
+            rversion: 4.6.1
             R_HOME: 'C:\RINSTALL'
             R_ARCH: /x64
             #
@@ -395,7 +395,7 @@ jobs:
             Platform: x64
             Configuration: Release
             #
-            rversion: 4.6.0
+            rversion: 4.6.1
             R_HOME: 'C:\RINSTALL'
             R_ARCH: /x64
             #

--- a/.github/workflows/buildPLRschedule.yml
+++ b/.github/workflows/buildPLRschedule.yml
@@ -22,7 +22,7 @@ on:
 
 jobs:
   build_test_install:
-    name: matid ${{ matrix.matid }} R ${{ matrix.rversion }} PGsrc ${{ matrix.pgSRCversion }} PGbin ${{ matrix.pgWINversion }} ${{ matrix.compilerEnv }} ${{ matrix.Platform }}  ${{ matrix.os }} ${{ matrix.Configuration }} R ${{ matrix.rversion }} PGSRC ${{ matrix.buildpgFromSRC }} PGSRCMETH ${{ matrix.buildpgFromSRCmethod }} SRCCTB ${{ matrix.buildpgANDplrInSRCcontrib }}
+    name: matid ${{ matrix.matid }} R ${{ matrix.rversion }} PGsrc ${{ matrix.pgSRCversion }} PGbin ${{ matrix.pgWINversion }} ${{ matrix.compilerEnv }} ${{ matrix.Platform }}  ${{ matrix.os }} ${{ matrix.Configuration }} PGSRC ${{ matrix.buildpgFromSRC }} PGSRCMETH ${{ matrix.buildpgFromSRCmethod }} SRCCTB ${{ matrix.buildpgANDplrInSRCcontrib }}
     runs-on: ${{ matrix.os }}
     # With "continue-on-error" (and with "fail-fast") emulate Appveyor "allow_failures"
     # Prevents a workflow run from failing when a job fails. Set to true to allow a workflow run to pass when this job fails.
@@ -137,7 +137,7 @@ jobs:
 #           Platform: x64
 #           Configuration: Debug
 #           #
-#           rversion: 4.6.0
+#           rversion: 4.6.1
 #           R_HOME: 'C:\RINSTALL'
 #           R_ARCH: /x64
 #           #
@@ -158,7 +158,7 @@ jobs:
           #  Platform: x64
           #  Configuration: Debug
             #
-          #  rversion: 4.6.0
+          #  rversion: 4.6.1
           #  R_HOME: 'C:\RINSTALL'
           #  R_ARCH: /x64
             #
@@ -184,28 +184,28 @@ jobs:
 
 
           # RSVP for FUTURE USE
-#         # R latest and PostgreSQL release candidate or beta (buildpgANDplrInSRCcontrib true)
-#         - matid: '04'
-#           os: windows-2025-vs2026
-#           GithubActionsIgnoreFail: true
-#           compilerEnv: UCRT64
-#           shellEnv: msys2 {0}
-#           compilerExe: gcc
-#           Platform: x64
-#           Configuration: Debug
-#           #
-#           rversion: 4.6.0
-#           R_HOME: 'C:\RINSTALL'
-#           R_ARCH: /x64
-#           #
-#           pgSRCversion: REL_19_STABLE
-#           PG_SOURCE: 'C:\PGSOURCE'
-#           buildpgFromSRC: true
-#           buildpgFromSRCmethod: meson
-#           PG_HOME: 'C:\PGINSTALL'
+          # R latest and PostgreSQL release candidate or beta (buildpgFromSRCmethod meson)
+          - matid: '04'
+            os: windows-2025-vs2026
+            GithubActionsIgnoreFail: true
+            compilerEnv: UCRT64
+            shellEnv: msys2 {0}
+            compilerExe: gcc
+            Platform: x64
+            Configuration: Debug
+            #
+            rversion: 4.6.1
+            R_HOME: 'C:\RINSTALL'
+            R_ARCH: /x64
+            #
+            pgSRCversion: REL_19_STABLE
+            PG_SOURCE: 'C:\PGSOURCE'
+            buildpgFromSRC: true
+            buildpgFromSRCmethod: meson
+            PG_HOME: 'C:\PGINSTALL'
 
 
-#         # R latest and PostgreSQL release candidate or beta (buildpgANDplrInSRCcontrib true)
+#         # R latest and PostgreSQL release candidate or beta (buildpgFromSRCmethod meson)
 #         - matid: '05'
 #           os: windows-2025-vs2026
 #           GithubActionsIgnoreFail: true
@@ -215,7 +215,7 @@ jobs:
 #           Platform: x64
 #           Configuration: Debug
 #           #
-#           rversion: 4.6.0
+#           rversion: 4.6.1
 #           R_HOME: 'C:\RINSTALL'
 #           R_ARCH: /x64
 #           #
@@ -271,7 +271,7 @@ jobs:
 #           Platform: x64
 #           Configuration: Release
 #           #
-#           rversion: 4.6.0
+#           rversion: 4.6.1
 #           R_HOME: 'C:\RINSTALL'
 #           R_ARCH: /x64
 #           #

--- a/.github/workflows/schedule.yml
+++ b/.github/workflows/schedule.yml
@@ -85,32 +85,39 @@ jobs:
           sudo /etc/init.d/postgresql stop
           sudo apt-get remove --purge postgresql\*
           sudo rm -rf /etc/postgresql /var/lib/postgresql
-          export RET=$(git ls-remote --tags https://github.com/postgres/postgres.git | cut -c 52- | grep -c 'REL_19_[0-9]')
+          export PGSRCVERSION=REL_19_
+          export ALLGITTAGS=$(git ls-remote --tags https://github.com/postgres/postgres.git | cut -c 52-)
+          quantity() { echo ${ALLGITTAGS} | tr " " "\n" | grep -c "${PGSRCVERSION}${MARK}[0-9]"; }
+          quality()  { echo ${ALLGITTAGS} | tr " " "\n" | grep -e "${PGSRCVERSION}${MARK}[0-9]" | tail -n 1; }
+          export MARK=""
+          export RET=$(quantity)
           if [ "${RET}" -gt "0" ]
           then
-            export GITTAG=$(git ls-remote --tags https://github.com/postgres/postgres.git | cut -c 52- | grep -e 'REL_19_[0-9]' | tail -n 1)
-            echo -n "Release(s) are found.  Taking the last Release . . . GITTAG: ${GITTAG}"
+            export SPECGITTAG=$(quality)
+            echo -n "Release(s) are found.  Taking the last Release . . . SPECGITTAG: ${SPECGITTAG}"
           else
-            export RET=$(git ls-remote --tags https://github.com/postgres/postgres.git | cut -c 52- | grep -c 'REL_19_RC[0-9]')
+            export MARK="RC"
+            export RET=$(quantity)
             echo "Release(s) are not found.  Trying Release Candidates."
             if [ "${RET}" -gt "0" ]
             then
-              export GITTAG=$(git ls-remote --tags https://github.com/postgres/postgres.git | cut -c 52- | grep -e 'REL_19_RC[0-9]' | tail -n 1)
-              echo -n "Release Candidate(s) are found.  Taking the last Release Candidate . . . GITTAG: ${GITTAG}"
+              export SPECGITTAG=$(quality)
+              echo -n "Release Candidate(s) are found.  Taking the last Release Candidate . . . SPECGITTAG: ${SPECGITTAG}"
             else
-              export RET=$(git ls-remote --tags https://github.com/postgres/postgres.git | cut -c 52- | grep -c 'REL_19_BETA[0-9]')
+              export MARK="BETA"
+              export RET=$(quantity)
               echo "Release Candidate(s) are not found. Trying Betas."
               if [ "${RET}" -gt "0" ]
               then
-                export GITTAG=$(git ls-remote --tags https://github.com/postgres/postgres.git | cut -c 52- | grep -e 'REL_19_BETA[0-9]' | tail -n 1)
-                echo -n "Beta(s) are found. Taking the last Beta . . . GITTAG: ${GITTAG}"
+                export SPECGITTAG=$(quality)
+                echo -n "Beta(s) are found. Taking the last Beta . . . SPECGITTAG: ${SPECGITTAG}"
               else
                 echo "Beta(s) are not found."
               fi
             fi
           fi
-          echo "GITTAG: ${GITTAG}"
-          git clone --branch $GITTAG --depth=1 https://github.com/postgres/postgres.git
+          echo "SPECGITTAG: ${SPECGITTAG}"
+          git clone --branch $SPECGITTAG --depth=1 https://github.com/postgres/postgres.git
           pushd postgres
           ./configure
           make

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -307,7 +307,7 @@ for:
   - if     "%APPVEYOR_BUILD_WORKER_IMAGE%"=="Visual Studio 2015" echo APPVEYOR_BUILD_WORKER_IMAGE is 2015
   # Make %x64% available for caching
   # a variable used in the Appveyor cach area must be defined in the init
-  - set gitrevshort=%APPVEYOR_REPO_COMMIT:~0,8%
+  - set gitrevshort=%APPVEYOR_REPO_COMMIT:~0,7%
   - ps: |
       # Set-PSDebug -Trace 2
 
@@ -580,7 +580,7 @@ for:
   - if     "%APPVEYOR_BUILD_WORKER_IMAGE%"=="Visual Studio 2015" echo APPVEYOR_BUILD_WORKER_IMAGE is 2015
   # Make %x64% available for caching
   # a variable used in the Appveyor cach area must be defined in the init
-  - set gitrevshort=%APPVEYOR_REPO_COMMIT:~0,8%
+  - set gitrevshort=%APPVEYOR_REPO_COMMIT:~0,7%
   - ps: |
       # Set-PSDebug -Trace 2
 
@@ -1283,7 +1283,7 @@ for:
   - copy %dll% tmp\lib
   - copy %dll:.dll=.pdb% tmp\symbols
   - dir tmp
-  - set var7z=plr-apvid-%apvid%-%APPVEYOR_REPO_COMMIT:~0,8%-%compiler%-%Platform%-R%rversion%-PG%pgversion%-%Configuration%.7z
+  - set var7z=plr-apvid-%apvid%-%APPVEYOR_REPO_COMMIT:~0,7%-%compiler%-%Platform%-R%rversion%-PG%pgversion%-%Configuration%.7z
   - 7z a -t7z -mmt24 -mx7 -r %var7z% .\tmp\* > nul
   - dir "%var7z%"
   - echo appveyor PushArtifact "%var7z%"


### PR DESCRIPTION
temporary PG REL_19_ tests on daily Github Actions UCRT64 pg-pre-19 branch  REL_19_STABLE

* Test daily on pg UCRT64 REL_19_STABLE (REL_19_BETA2+ ... REL_19_RC_+)
* Bump Windows R version from 4.6.0 to 4.6.1
* Aesthetic fix of Appveyor Cygwin 32 build of too long Gith Hash
* Aesthetic fix of Github Actions job name redundant 2nd "R matrix.rversion"
* Refactor(simplify) Linux builds' pg version release RC BETA detection